### PR TITLE
fix: make set:html always escape HTML properly

### DIFF
--- a/.changeset/wild-numbers-act.md
+++ b/.changeset/wild-numbers-act.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/compiler-binding": patch
+"@astrojs/compiler-rs": patch
+---
+
+Fixed an issue where define:vars scripts would not be handled correctly

--- a/.changeset/young-days-sneeze.md
+++ b/.changeset/young-days-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/compiler-binding": patch
+"@astrojs/compiler-rs": patch
+---
+
+Fixes an issue where set:html did not work correctly in certain cases

--- a/crates/astro_codegen/src/printer/components.rs
+++ b/crates/astro_codegen/src/printer/components.rs
@@ -172,8 +172,7 @@ impl<'a> AstroCodegen<'a> {
         }
 
         // Check for set:html or set:text on components (including Fragment)
-        let set_directive =
-            Self::extract_set_html_value(&el.opening_element.attributes);
+        let set_directive = Self::extract_set_html_value(&el.opening_element.attributes);
 
         self.print("${");
         self.print(runtime::RENDER_COMPONENT);

--- a/crates/astro_codegen/src/printer/components.rs
+++ b/crates/astro_codegen/src/printer/components.rs
@@ -172,7 +172,8 @@ impl<'a> AstroCodegen<'a> {
         }
 
         // Check for set:html or set:text on components (including Fragment)
-        let set_directive = Self::extract_set_html_value(&el.opening_element.attributes);
+        let set_directive =
+            Self::extract_set_html_value(&el.opening_element.attributes);
 
         self.print("${");
         self.print(runtime::RENDER_COMPONENT);
@@ -302,13 +303,14 @@ impl<'a> AstroCodegen<'a> {
                 if is_html || is_text {
                     let (value, needs_unescape, is_raw_text) = match &attr.value {
                         Some(JSXAttributeValue::StringLiteral(lit)) => {
-                            // String literals don't need $$unescapeHTML
                             let raw_value = lit.value.as_str();
                             if is_html {
+                                // set:html with string literal: needs $$unescapeHTML like any
+                                // other value — the user is asking for raw HTML injection.
                                 let decoded = decode_html_entities(raw_value);
                                 (
                                     Some(format!("\"{}\"", escape_double_quotes(&decoded))),
-                                    false,
+                                    true,
                                     false,
                                 )
                             } else {
@@ -318,12 +320,9 @@ impl<'a> AstroCodegen<'a> {
                         }
                         Some(JSXAttributeValue::ExpressionContainer(expr)) => {
                             if let Some(e) = expr.expression.as_expression() {
-                                // set:html needs $$unescapeHTML for expressions, but NOT for
-                                // template literals — the Go compiler passes template literals
-                                // through as-is without unescaping.
-                                let is_template_literal =
-                                    matches!(e, Expression::TemplateLiteral(_));
-                                let needs_unescape = is_html && !is_template_literal;
+                                // set:html always needs $$unescapeHTML — its purpose is to
+                                // inject raw HTML, and $$render escapes by default.
+                                let needs_unescape = is_html;
                                 let code = expr_to_string(e);
                                 return Some((code, is_html, needs_unescape, false, attr.span));
                             }

--- a/crates/astro_codegen/src/printer/elements.rs
+++ b/crates/astro_codegen/src/printer/elements.rs
@@ -6,7 +6,7 @@
 //! attributes, and element classification helpers (`is_void_element`,
 //! `is_head_element`).
 
-use super::escape::{escape_double_quotes, escape_html_attribute};
+use super::escape::{escape_double_quotes, escape_html_attribute, escape_template_literal};
 use super::runtime;
 use super::whitespace::{has_is_raw_attr, is_raw_element_name};
 use super::{AstroCodegen, expr_to_string};
@@ -184,6 +184,30 @@ impl<'a> AstroCodegen<'a> {
             } else {
                 // For literals (string/template) or set:text expression, just interpolate
                 self.print(&format!("${{{value}}}"));
+            }
+        } else if name == "script"
+            && el
+                .children
+                .iter()
+                .any(|c| matches!(c, JSXChild::AstroScript(_)))
+        {
+            // The script content was parsed as JS by oxc (AstroScript child).
+            // For non-hoisted scripts (e.g. is:inline), emit the raw source text
+            // verbatim. The content lies between the opening tag end and closing
+            // tag start in the original source.
+            let content_start = el.opening_element.span.end as usize;
+            let content_end = el
+                .closing_element
+                .as_ref()
+                .map(|c| c.span.start as usize)
+                .unwrap_or(content_start);
+            if content_start < content_end {
+                let raw = &self.source_text[content_start..content_end];
+                self.add_source_mapping_for_span(oxc_span::Span::new(
+                    content_start as u32,
+                    content_end as u32,
+                ));
+                self.print(&escape_template_literal(raw));
             }
         } else {
             // Regular children with compact-aware printing

--- a/crates/astro_codegen/src/printer/elements.rs
+++ b/crates/astro_codegen/src/printer/elements.rs
@@ -128,7 +128,8 @@ impl<'a> AstroCodegen<'a> {
         self.maybe_insert_render_head(name);
 
         // Extract set:html and set:text directives
-        let set_directive = Self::extract_set_directive(&el.opening_element.attributes);
+        let set_directive =
+            Self::extract_set_directive(&el.opening_element.attributes);
 
         // Determine if this element should receive a scope identifier
         let scope_id = if self.has_scoped_styles && css_scoping::should_scope_element(name) {
@@ -302,26 +303,22 @@ impl<'a> AstroCodegen<'a> {
                                 // set:text with string literal: inline raw text without ${}
                                 (lit.value.as_str().to_string(), false, true)
                             } else {
-                                // set:html with string literal: use ${"content"}
+                                // set:html with string literal: needs $$unescapeHTML like any
+                                // other value — the user is asking for raw HTML injection.
                                 (
                                     format!("\"{}\"", escape_double_quotes(lit.value.as_str())),
-                                    false,
+                                    true,
                                     false,
                                 )
                             }
                         }
                         Some(JSXAttributeValue::ExpressionContainer(expr)) => {
                             let mut value_str = String::new();
-                            let mut is_template_literal = false;
                             if let Some(e) = expr.expression.as_expression() {
                                 value_str = expr_to_string(e);
-                                is_template_literal = matches!(e, Expression::TemplateLiteral(_));
                             }
-                            // set:html always needs $$unescapeHTML — the $$render tagged
-                            // template escapes HTML by default, so all expressions (including
-                            // template literals) must be wrapped in $$unescapeHTML to be
-                            // rendered as raw HTML.
-                            let _ = is_template_literal;
+                            // set:html always needs $$unescapeHTML — its purpose is to inject
+                            // raw HTML, and $$render escapes by default.
                             let needs_unescape = directive_type == "html";
                             (value_str, needs_unescape, false)
                         }

--- a/crates/astro_codegen/src/printer/elements.rs
+++ b/crates/astro_codegen/src/printer/elements.rs
@@ -128,8 +128,7 @@ impl<'a> AstroCodegen<'a> {
         self.maybe_insert_render_head(name);
 
         // Extract set:html and set:text directives
-        let set_directive =
-            Self::extract_set_directive(&el.opening_element.attributes);
+        let set_directive = Self::extract_set_directive(&el.opening_element.attributes);
 
         // Determine if this element should receive a scope identifier
         let scope_id = if self.has_scoped_styles && css_scoping::should_scope_element(name) {

--- a/crates/astro_codegen/src/printer/expressions.rs
+++ b/crates/astro_codegen/src/printer/expressions.rs
@@ -106,7 +106,8 @@ impl<'a> AstroCodegen<'a> {
                 let is_explicit_fragment = !frag.opening_fragment.span.is_empty();
 
                 if is_explicit_fragment {
-                    // Explicit <>...</> syntax gets wrapped in $$renderComponent with Fragment
+                    // Explicit <>...</> syntax gets wrapped in $$renderComponent with Fragment.
+                    // Whitespace inside <>..</> is intentional authored content — preserve it.
                     let slot_params = self.get_slot_params();
                     self.print(runtime::RENDER);
                     self.print("`${");
@@ -123,7 +124,9 @@ impl<'a> AstroCodegen<'a> {
                     }
                     self.print("`,})}`");
                 } else {
-                    // Implicit fragments (multiple JSX siblings) are just wrapped in $$render`...`
+                    // Implicit fragments (multiple JSX siblings) are just wrapped
+                    // in $$render`...`. Edge whitespace-only text nodes are
+                    // stripped by the parser, so we render children directly.
                     self.print(runtime::RENDER);
                     self.print("`");
                     self.print_jsx_children_compact(&frag.children);

--- a/crates/astro_codegen/src/printer/mod.rs
+++ b/crates/astro_codegen/src/printer/mod.rs
@@ -15,9 +15,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::options::CompactMode;
 use crate::scanner::{
-    AstroScanner, HoistedScriptType as InternalHoistedScriptType, ScanResult,
-    get_jsx_attribute_name, get_jsx_element_name, is_component_name, is_custom_element,
-    should_hoist_script,
+    AstroScanner, ScanResult, get_jsx_attribute_name, get_jsx_element_name, is_component_name,
+    is_custom_element, should_hoist_script,
 };
 use crate::{SourcemapOption, TransformOptions};
 use whitespace::{TextPosition, collapse_html, collapse_jsx};
@@ -437,28 +436,7 @@ impl<'a> AstroCodegen<'a> {
     pub fn build(mut self, root: &'a AstroRoot<'a>) -> TransformResult {
         self.print_astro_root(root);
 
-        // Build public hoisted scripts from internal representation.
-        // DefineVars scripts are rendered inline as IIFEs and are NOT bundled as
-        // virtual modules — exclude them from the public scripts array.
-        let scripts = self
-            .scan_result
-            .hoisted_scripts
-            .iter()
-            .filter_map(|s| match s.script_type {
-                InternalHoistedScriptType::External => Some(TransformResultHoistedScript {
-                    script_type: HoistedScriptType::External,
-                    src: s.src.clone(),
-                    code: None,
-                }),
-                InternalHoistedScriptType::Inline => Some(TransformResultHoistedScript {
-                    script_type: HoistedScriptType::Inline,
-                    code: s.value.clone(),
-                    src: None,
-                }),
-                // DefineVars are printed inline — skip them here
-                InternalHoistedScriptType::DefineVars => None,
-            })
-            .collect();
+        let scripts = self.scan_result.hoisted_scripts.clone();
 
         // Build public hydrated components from internal representation
         let hydrated_components = self
@@ -783,33 +761,27 @@ impl<'a> AstroCodegen<'a> {
             "[]".to_string()
         } else {
             let items: Vec<String> = self
-                .scan_result.hoisted_scripts
+                .scan_result
+                .hoisted_scripts
                 .iter()
-                .map(|script| {
-                    match script.script_type {
-                        InternalHoistedScriptType::Inline => {
-                            let value = script.value.as_deref().unwrap_or("");
-                            let escaped = escape_template_literal(value);
-                            format!("{{ type: \"inline\", value: `{escaped}` }}")
-                        }
-                        InternalHoistedScriptType::External => {
-                            let src = script.src.as_deref().unwrap_or("");
-                            let escaped = escape_single_quote(src);
-                            format!("{{ type: \"external\", src: '{escaped}' }}")
-                        }
-                        InternalHoistedScriptType::DefineVars => {
-                            let value = script.value.as_deref().unwrap_or("");
-                            let keys = script.keys.as_deref().unwrap_or("");
-                            let escaped_value = escape_template_literal(value);
-                            let escaped_keys = escape_single_quote(keys);
-                            format!(
-                                "{{ type: \"define:vars\", value: `{escaped_value}`, keys: '{escaped_keys}' }}"
-                            )
-                        }
+                .map(|script| match script.script_type {
+                    HoistedScriptType::Inline => {
+                        let code = script.code.as_deref().unwrap_or("");
+                        let escaped = escape_template_literal(code);
+                        format!("{{ type: \"inline\", value: `{escaped}` }}")
+                    }
+                    HoistedScriptType::External => {
+                        let src = script.src.as_deref().unwrap_or("");
+                        let escaped = escape_single_quote(src);
+                        format!("{{ type: \"external\", src: '{escaped}' }}")
                     }
                 })
                 .collect();
-            format!("[{}]", items.join(", "))
+            if items.is_empty() {
+                "[]".to_string()
+            } else {
+                format!("[{}]", items.join(", "))
+            }
         };
 
         let metadata_url = match &self.options.filename {
@@ -1256,7 +1228,8 @@ impl<'a> AstroCodegen<'a> {
                 self.print_jsx_spread_child(spread);
             }
             JSXChild::AstroScript(_script) => {
-                // AstroScript is handled specially — already parsed TypeScript
+                // AstroScript children are handled at the element level (print_html_element)
+                // where we have access to the parent element's spans to derive the content range.
             }
             JSXChild::AstroDoctype(_doctype) => {
                 // Doctype is typically stripped in the output
@@ -1319,8 +1292,6 @@ impl<'a> AstroCodegen<'a> {
                 let is_lone = visible_count == 1;
                 let pos = TextPosition {
                     is_lone_child: is_lone,
-                    is_first_in_expression: false,
-                    is_last_in_expression: false,
                 };
                 self.print_jsx_text_with_pos(text, pos);
             } else {
@@ -1338,6 +1309,97 @@ impl<'a> AstroCodegen<'a> {
         if name == "style" && !self.in_non_hoistable && self.should_extract_style(el) {
             // Style was already extracted during prescan — just skip it from template
             return;
+        }
+
+        // Handle <script define:vars={...}> — these are rendered inline (not bundled
+        // via $$renderScript) regardless of whether is:inline is present or not.
+        // - Without type="module": IIFE wrapping  <script>(function(){${$$defineScriptVars({...})}...})();</script>
+        // - With type="module": no IIFE (imports are illegal inside functions)
+        //   <script type="module">${$$defineScriptVars({...})}...</script>
+        if name == "script" {
+            let define_vars_expr = el.opening_element.attributes.iter().find_map(|attr| {
+                if let JSXAttributeItem::Attribute(attr) = attr
+                    && get_jsx_attribute_name(&attr.name) == "define:vars"
+                {
+                    return match &attr.value {
+                        Some(JSXAttributeValue::StringLiteral(lit)) => {
+                            Some(format!("'{}'", lit.value.as_str()))
+                        }
+                        Some(JSXAttributeValue::ExpressionContainer(expr)) => {
+                            expr.expression.as_expression().map(expr_to_string)
+                        }
+                        _ => None,
+                    };
+                }
+                None
+            });
+
+            if let Some(define_vars_expr) = define_vars_expr {
+                self.add_source_mapping_for_span(el.opening_element.span);
+
+                let is_module = el.opening_element.attributes.iter().any(|attr| {
+                    if let JSXAttributeItem::Attribute(attr) = attr {
+                        let attr_name = get_jsx_attribute_name(&attr.name);
+                        if attr_name == "type"
+                            && let Some(JSXAttributeValue::StringLiteral(lit)) = &attr.value {
+                                return lit.value == "module";
+                            }
+                    }
+                    false
+                });
+
+                // Get script content — either from JSXText children (raw text) or
+                // from the raw source span when the child is an AstroScript (oxc
+                // parsed the content as JS).
+                let has_astro_script = el
+                    .children
+                    .iter()
+                    .any(|c| matches!(c, JSXChild::AstroScript(_)));
+                let text_content: String = if has_astro_script {
+                    let start = el.opening_element.span.end as usize;
+                    let end = el
+                        .closing_element
+                        .as_ref()
+                        .map(|c| c.span.start as usize)
+                        .unwrap_or(start);
+                    self.source_text[start..end].to_string()
+                } else {
+                    el.children
+                        .iter()
+                        .filter_map(|child| {
+                            if let JSXChild::Text(t) = child {
+                                Some(t.value.as_str())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect()
+                };
+
+                if is_module {
+                    // type="module" — no IIFE, just prepend $$defineScriptVars
+                    self.print("<script type=\"module\">");
+                    self.print("${");
+                    self.print(runtime::DEFINE_SCRIPT_VARS);
+                    self.print("(");
+                    self.print(&define_vars_expr);
+                    self.print(")}");
+                    self.print(&escape_template_literal(&text_content));
+                    self.print("</script>");
+                } else {
+                    // No type="module" — wrap in IIFE
+                    self.print("<script>");
+                    self.print("(function(){${");
+                    self.print(runtime::DEFINE_SCRIPT_VARS);
+                    self.print("(");
+                    self.print(&define_vars_expr);
+                    self.print(")}");
+                    self.print(&escape_template_literal(&text_content));
+                    self.print("})();");
+                    self.print("</script>");
+                }
+                return;
+            }
         }
 
         // Handle <script> elements that should be hoisted
@@ -1363,49 +1425,6 @@ impl<'a> AstroCodegen<'a> {
 
         if name == "script" && is_hoisted_script {
             self.add_source_mapping_for_span(el.opening_element.span);
-
-            // define:vars scripts are NOT bundled via $$renderScript — they stay
-            // inline in the template as an IIFE: <script>(function(){${$$defineScriptVars({...})}...})();</script>
-            let define_vars_expr = el.opening_element.attributes.iter().find_map(|attr| {
-                if let JSXAttributeItem::Attribute(attr) = attr
-                    && get_jsx_attribute_name(&attr.name) == "define:vars"
-                {
-                    return match &attr.value {
-                        Some(JSXAttributeValue::StringLiteral(lit)) => {
-                            Some(format!("'{}'", lit.value.as_str()))
-                        }
-                        Some(JSXAttributeValue::ExpressionContainer(expr)) => {
-                            expr.expression.as_expression().map(expr_to_string)
-                        }
-                        _ => None,
-                    };
-                }
-                None
-            });
-
-            if let Some(define_vars_expr) = define_vars_expr {
-                let text_content: String = el
-                    .children
-                    .iter()
-                    .filter_map(|child| {
-                        if let JSXChild::Text(t) = child {
-                            Some(t.value.as_str())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                self.print("<script>");
-                self.print("(function(){${");
-                self.print(runtime::DEFINE_SCRIPT_VARS);
-                self.print("(");
-                self.print(&define_vars_expr);
-                self.print(")}");
-                self.print(&escape_template_literal(&text_content));
-                self.print("})();");
-                self.print("</script>");
-                return;
-            }
 
             let filename = self
                 .options
@@ -3250,6 +3269,65 @@ import MyComp from 'test';
     }
 
     #[test]
+    fn test_script_inside_html_comment_not_hoisted() {
+        // Full no_extra_script_tag fixture content
+        let source = r#"<!-- Global Metadata -->
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+
+<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<link rel="alternate icon" type="image/x-icon" href="/favicon.ico" />
+
+<link rel="sitemap" href="/sitemap.xml"/>
+
+<!-- Global CSS -->
+<link rel="stylesheet" href="/theme.css" />
+<link rel="stylesheet" href="/code.css" />
+<link rel="stylesheet" href="/index.css" />
+
+<!-- Preload Fonts -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital@0;1&display=swap" rel="stylesheet">
+
+<!-- Scrollable a11y code helper -->
+<script type="module" src="/make-scrollable-code-focusable.js" />
+
+<!-- This is intentionally inlined to avoid FOUC -->
+<script is:inline>
+  const root = document.documentElement;
+  const theme = localStorage.getItem('theme');
+  if (theme === 'dark' || (!theme) && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    root.classList.add('theme-dark');
+  } else {
+    root.classList.remove('theme-dark');
+  }
+</script>
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-TEL60V1WM9"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-TEL60V1WM9');
+</script> -->"#;
+
+        let output = compile_astro(source);
+        // The commented-out scripts should be inside an HTML comment in the template,
+        // NOT in hoisted metadata. Verify hoisted is empty.
+        assert!(
+            output.contains("hoisted: []"),
+            "hoisted should be empty: {output}"
+        );
+        // Verify the HTML comment containing script tags IS rendered in the template
+        assert!(
+            output.contains("<!-- <script async"),
+            "HTML comment with script tags should be rendered: {output}"
+        );
+    }
+
+    #[test]
     fn test_script_src_with_data_attr_not_hoisted() {
         // `<script src="..." data-foo="bar">` — any extra attr blocks hoisting.
         let source = r#"<script src="/script.js" data-foo="bar"></script>"#;
@@ -3542,6 +3620,75 @@ import Bar from './Bar.astro';
         assert!(
             output.contains("$$renderComponent"),
             "JSX elements inside arrays must use $$renderComponent: {output}"
+        );
+    }
+
+    // -- Expression edge whitespace trimming tests --
+    //
+    // Implicit JSX fragments inside expressions ({ <el/>... }) should not
+    // have whitespace-only text nodes at the leading/trailing edges inside
+    // the $$render backtick. Explicit fragments (<>...</>) preserve their
+    // whitespace.
+
+    #[test]
+    fn test_expression_implicit_fragment_trims_leading_whitespace() {
+        // Leading \n\t before <li> should be trimmed
+        let source = "<ul>{\n\t<li>one</li>\n}</ul>";
+        let output = compile_astro(source);
+        // The backtick should open right before <li>, not with leading whitespace
+        assert!(
+            output.contains("$$render`<li>one</li>"),
+            "implicit fragment should trim leading whitespace: {output}"
+        );
+    }
+
+    #[test]
+    fn test_expression_implicit_fragment_trims_trailing_whitespace() {
+        // Trailing \n after </li> should be trimmed
+        let source = "<ul>{<li>one</li>\n}</ul>";
+        let output = compile_astro(source);
+        assert!(
+            output.contains("<li>one</li>`"),
+            "implicit fragment should trim trailing whitespace: {output}"
+        );
+    }
+
+    #[test]
+    fn test_expression_implicit_fragment_preserves_interior_whitespace() {
+        // Whitespace between elements should be preserved
+        let source = "<ul>{\n\t<li>one</li>\n\t<li>two</li>\n}</ul>";
+        let output = compile_astro(source);
+        assert!(
+            output.contains("<li>one</li>\n\t<li>two</li>"),
+            "implicit fragment should preserve interior whitespace: {output}"
+        );
+    }
+
+    #[test]
+    fn test_expression_explicit_fragment_preserves_all_whitespace() {
+        // Explicit <>...</> should keep leading/trailing whitespace
+        let source = "<div>{<>\n  <span>hi</span>\n</>}</div>";
+        let output = compile_astro(source);
+        // The whitespace after <> and before </> should be inside the backtick
+        assert!(
+            output.contains("$$render`\n  <span>hi</span>\n`"),
+            "explicit fragment should preserve all whitespace: {output}"
+        );
+    }
+
+    #[test]
+    fn test_expression_implicit_fragment_inline_elements_no_extra_space() {
+        // Inline elements shouldn't get extra whitespace injected
+        let source = "<span>{\n  <strong>hello</strong>\n  <em>world</em>\n}</span>";
+        let output = compile_astro(source);
+        // Leading/trailing \n should be trimmed — no extra space at edges
+        assert!(
+            output.contains("$$render`<strong>hello</strong>"),
+            "should not inject leading whitespace before inline element: {output}"
+        );
+        assert!(
+            output.contains("<em>world</em>`"),
+            "should not inject trailing whitespace after inline element: {output}"
         );
     }
 }

--- a/crates/astro_codegen/src/printer/mod.rs
+++ b/crates/astro_codegen/src/printer/mod.rs
@@ -1341,9 +1341,10 @@ impl<'a> AstroCodegen<'a> {
                     if let JSXAttributeItem::Attribute(attr) = attr {
                         let attr_name = get_jsx_attribute_name(&attr.name);
                         if attr_name == "type"
-                            && let Some(JSXAttributeValue::StringLiteral(lit)) = &attr.value {
-                                return lit.value == "module";
-                            }
+                            && let Some(JSXAttributeValue::StringLiteral(lit)) = &attr.value
+                        {
+                            return lit.value == "module";
+                        }
                     }
                     false
                 });

--- a/crates/astro_codegen/src/printer/style.rs
+++ b/crates/astro_codegen/src/printer/style.rs
@@ -9,7 +9,7 @@ use oxc_ast::ast::*;
 use crate::css_scoping;
 use crate::scanner::{get_jsx_attribute_name, get_jsx_element_name};
 
-use super::{expr_to_string, AstroCodegen};
+use super::{AstroCodegen, expr_to_string};
 
 /// Metadata about an extractable `<style>` block in an Astro component.
 ///

--- a/crates/astro_codegen/src/printer/style.rs
+++ b/crates/astro_codegen/src/printer/style.rs
@@ -9,7 +9,7 @@ use oxc_ast::ast::*;
 use crate::css_scoping;
 use crate::scanner::{get_jsx_attribute_name, get_jsx_element_name};
 
-use super::{AstroCodegen, expr_to_string};
+use super::{expr_to_string, AstroCodegen};
 
 /// Metadata about an extractable `<style>` block in an Astro component.
 ///

--- a/crates/astro_codegen/src/printer/whitespace.rs
+++ b/crates/astro_codegen/src/printer/whitespace.rs
@@ -68,10 +68,6 @@ pub(super) fn has_is_raw_attr(attrs: &[JSXAttributeItem<'_>]) -> bool {
 pub(super) struct TextPosition {
     /// Whether this text node is the only child (no siblings).
     pub is_lone_child: bool,
-    /// Whether this text node is the first child of an expression container.
-    pub is_first_in_expression: bool,
-    /// Whether this text node is the last child of an expression container.
-    pub is_last_in_expression: bool,
 }
 
 /// Apply `CompactMode::Html` whitespace collapsing to a text value.
@@ -91,25 +87,6 @@ pub(super) fn collapse_html(
 ) -> Option<String> {
     if in_raw_element {
         return Some(text.to_string());
-    }
-
-    // Expression boundary trimming: fully strip leading whitespace from the
-    // first child of an expression container, and trailing whitespace from the
-    // last child. After trimming, if the result is empty we emit nothing.
-    if pos.is_first_in_expression || pos.is_last_in_expression {
-        let mut s = text.to_string();
-        if pos.is_first_in_expression {
-            // Trim leading whitespace
-            s = s.trim_start().to_string();
-        }
-        if pos.is_last_in_expression {
-            // Trim trailing whitespace
-            s = s.trim_end().to_string();
-        }
-        if s.is_empty() {
-            return None;
-        }
-        return Some(s);
     }
 
     // Pure whitespace text node?
@@ -175,24 +152,22 @@ pub(super) fn collapse_jsx(text: &str, in_raw_element: bool) -> Option<String> {
 mod tests {
     use super::*;
 
-    fn pos(lone: bool, first_expr: bool, last_expr: bool) -> TextPosition {
+    fn pos(lone: bool) -> TextPosition {
         TextPosition {
             is_lone_child: lone,
-            is_first_in_expression: first_expr,
-            is_last_in_expression: last_expr,
         }
     }
 
     fn html(text: &str) -> Option<String> {
-        collapse_html(text, false, false, pos(false, false, false))
+        collapse_html(text, false, false, pos(false))
     }
 
     fn html_lone(text: &str) -> Option<String> {
-        collapse_html(text, false, false, pos(true, false, false))
+        collapse_html(text, false, false, pos(true))
     }
 
     fn html_insensitive(text: &str) -> Option<String> {
-        collapse_html(text, false, true, pos(false, false, false))
+        collapse_html(text, false, true, pos(false))
     }
 
     // --- Html mode: whitespace-only text ---
@@ -245,37 +220,11 @@ mod tests {
 
     #[test]
     fn html_raw_element_verbatim() {
-        let p = pos(false, false, false);
+        let p = pos(false);
         assert_eq!(
             collapse_html("  hello  ", true, false, p),
             Some("  hello  ".to_string())
         );
-    }
-
-    // --- Html mode: expression boundary ---
-
-    #[test]
-    fn html_expression_first_child_trims_leading() {
-        let p = pos(false, true, false);
-        assert_eq!(
-            collapse_html("\n  foo\n", false, false, p),
-            Some("foo\n".to_string())
-        );
-    }
-
-    #[test]
-    fn html_expression_last_child_trims_trailing() {
-        let p = pos(false, false, true);
-        assert_eq!(
-            collapse_html("\n  foo\n  ", false, false, p),
-            Some("\n  foo".to_string())
-        );
-    }
-
-    #[test]
-    fn html_expression_whitespace_only_first_removed() {
-        let p = pos(false, true, false);
-        assert_eq!(collapse_html("\n  \t", false, false, p), None);
     }
 
     // --- Jsx mode ---

--- a/crates/astro_codegen/src/scanner.rs
+++ b/crates/astro_codegen/src/scanner.rs
@@ -11,39 +11,7 @@ use rustc_hash::FxHashSet;
 
 use oxc_allocator::Allocator;
 
-/// Information about an imported component.
-#[derive(Debug, Clone)]
-pub struct ComponentImportInfo {
-    /// The import specifier (e.g., "../components")
-    pub specifier: String,
-    /// The export name ("default" for default imports, otherwise the named export)
-    pub export_name: String,
-    /// Whether this is a namespace import (import * as x)
-    pub is_namespace: bool,
-}
-
-/// Type of hoisted script (internal representation).
-#[derive(Debug, Clone)]
-pub enum HoistedScriptType {
-    /// Inline script: `{ type: "inline", value: \`...\` }`
-    Inline,
-    /// External script with src: `{ type: "external", src: '...' }`
-    External,
-    /// Script with define:vars: `{ type: "define:vars", value: \`...\`, keys: '...' }`
-    DefineVars,
-}
-
-/// Information about a hoisted script (internal representation).
-#[derive(Debug, Clone)]
-pub struct HoistedScript {
-    pub script_type: HoistedScriptType,
-    /// The script content (for inline and define:vars)
-    pub value: Option<String>,
-    /// The external src (for external scripts)
-    pub src: Option<String>,
-    /// The variable keys (for define:vars)
-    pub keys: Option<String>,
-}
+use crate::printer::result::{HoistedScriptType, TransformResultHoistedScript};
 
 /// Information about a hydrated component.
 #[derive(Debug, Clone)]
@@ -78,7 +46,7 @@ pub struct ScanResult {
     /// Collected hydration directive names (e.g., "load", "visible", "only")
     pub hydration_directives: Vec<String>,
     /// Collected hoisted scripts
-    pub hoisted_scripts: Vec<HoistedScript>,
+    pub hoisted_scripts: Vec<TransformResultHoistedScript>,
 }
 
 /// Scans an Astro AST to collect metadata in a single pass.
@@ -107,7 +75,7 @@ pub struct AstroScanner<'a> {
     /// Hydration directive names
     hydration_directives: Vec<String>,
     /// Collected hoisted scripts
-    hoisted_scripts: Vec<HoistedScript>,
+    hoisted_scripts: Vec<TransformResultHoistedScript>,
 }
 
 impl<'a> AstroScanner<'a> {
@@ -248,60 +216,31 @@ impl<'a> AstroScanner<'a> {
         attrs: &[&JSXAttributeItem<'a>],
     ) {
         let mut src_value: Option<String> = None;
-        let mut define_vars_value: Option<String> = None;
-        let mut define_vars_keys: Option<String> = None;
 
         for attr in attrs {
             if let JSXAttributeItem::Attribute(attr) = attr {
                 let attr_name = get_jsx_attribute_name(&attr.name);
-                if attr_name == "src" {
-                    if let Some(JSXAttributeValue::StringLiteral(lit)) = &attr.value {
-                        src_value = Some(lit.value.to_string());
-                    }
-                } else if attr_name == "define:vars"
-                    && let Some(JSXAttributeValue::ExpressionContainer(container)) = &attr.value
-                    && let Some(expr) = container.expression.as_expression()
-                    && let Expression::ObjectExpression(obj) = expr
+                if attr_name == "src"
+                    && let Some(JSXAttributeValue::StringLiteral(lit)) = &attr.value
                 {
-                    let keys: Vec<String> = obj
-                        .properties
-                        .iter()
-                        .filter_map(|prop| {
-                            if let ObjectPropertyKind::ObjectProperty(p) = prop {
-                                Some(get_property_key_name(&p.key))
-                            } else {
-                                None
-                            }
-                        })
-                        .collect();
-                    define_vars_keys = Some(keys.join(","));
-                    define_vars_value = Some(get_script_content(self.allocator, program));
+                    src_value = Some(lit.value.to_string());
                 }
             }
         }
 
-        if let Some(keys) = define_vars_keys {
-            self.hoisted_scripts.push(HoistedScript {
-                script_type: HoistedScriptType::DefineVars,
-                value: Some(define_vars_value.unwrap_or_default()),
-                src: None,
-                keys: Some(keys),
-            });
-        } else if let Some(src) = src_value {
-            self.hoisted_scripts.push(HoistedScript {
+        if let Some(src) = src_value {
+            self.hoisted_scripts.push(TransformResultHoistedScript {
                 script_type: HoistedScriptType::External,
-                value: None,
+                code: None,
                 src: Some(src),
-                keys: None,
             });
         } else {
             let content = get_script_content(self.allocator, program);
             if !content.is_empty() {
-                self.hoisted_scripts.push(HoistedScript {
+                self.hoisted_scripts.push(TransformResultHoistedScript {
                     script_type: HoistedScriptType::Inline,
-                    value: Some(content),
+                    code: Some(content),
                     src: None,
-                    keys: None,
                 });
             }
         }
@@ -327,11 +266,10 @@ impl<'a> AstroScanner<'a> {
         }
 
         if let Some(src) = src_value {
-            self.hoisted_scripts.push(HoistedScript {
+            self.hoisted_scripts.push(TransformResultHoistedScript {
                 script_type: HoistedScriptType::External,
-                value: None,
+                code: None,
                 src: Some(src),
-                keys: None,
             });
         } else {
             let content: String = children
@@ -348,11 +286,10 @@ impl<'a> AstroScanner<'a> {
 
             let content = content.trim();
             if !content.is_empty() {
-                self.hoisted_scripts.push(HoistedScript {
+                self.hoisted_scripts.push(TransformResultHoistedScript {
                     script_type: HoistedScriptType::Inline,
-                    value: Some(content.to_string()),
+                    code: Some(content.to_string()),
                     src: None,
-                    keys: None,
                 });
             }
         }
@@ -375,9 +312,12 @@ impl<'a> Visit<'a> for AstroScanner<'a> {
         // Check for hoistable scripts — if we collect one, skip walking
         // children to avoid visit_astro_script double-collecting the same script.
         let name = get_jsx_element_name(&el.opening_element.name);
-        if name == "script" && should_hoist_script(&el.opening_element.attributes) {
-            self.try_collect_script(el);
-            // Don't walk children — we already processed the AstroScript child
+        if name == "script" {
+            if should_hoist_script(&el.opening_element.attributes) {
+                self.try_collect_script(el);
+            }
+            // Don't walk children for any <script> element — AstroScript children
+            // inside non-hoistable scripts (e.g. is:inline) must not be collected.
             return;
         }
 
@@ -439,6 +379,8 @@ pub fn is_custom_element(name: &str) -> bool {
     name.contains('-')
 }
 
+/// Returns `true` if a `<script>` element should be hoisted (bundled via
+/// `$$renderScript`).
 pub fn should_hoist_script(attrs: &oxc_allocator::Vec<'_, JSXAttributeItem<'_>>) -> bool {
     let mut has_type_module = false;
     let mut has_src = false;
@@ -467,12 +409,8 @@ pub fn should_hoist_script(attrs: &oxc_allocator::Vec<'_, JSXAttributeItem<'_>>)
         }
     }
 
-    if is_inline {
+    if is_inline || has_define_vars {
         return false;
-    }
-
-    if has_define_vars {
-        return true;
     }
 
     // A script with a `src` pointing to an external file is only hoistable if
@@ -485,14 +423,6 @@ pub fn should_hoist_script(attrs: &oxc_allocator::Vec<'_, JSXAttributeItem<'_>>)
 
     // Scripts with no attributes at all, or with just `type="module"`, are hoistable.
     attrs.is_empty() || (has_type_module && !has_other)
-}
-
-fn get_property_key_name(key: &PropertyKey<'_>) -> String {
-    match key {
-        PropertyKey::StaticIdentifier(ident) => ident.name.to_string(),
-        PropertyKey::StringLiteral(lit) => lit.value.to_string(),
-        _ => String::new(),
-    }
 }
 
 /// Get the script content as a string by codegen-ing the program.

--- a/crates/astro_codegen/tests/fixtures/complex_recursive_component.snap
+++ b/crates/astro_codegen/tests/fixtures/complex_recursive_component.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/complex_recursive_component.astro
 ---
-import { Fragment, render as $$render, createAstro as $$createAstro, createComponent as $$createComponent, renderComponent as $$renderComponent, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { Fragment, render as $$render, createAstro as $$createAstro, createComponent as $$createComponent, renderComponent as $$renderComponent, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -15,6 +15,6 @@ const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
 	const Astro = $$result.createAstro($$props, $$slots);
 	Astro.self = $$Component;
-	return $$render`${$$render`${$$renderComponent($$result, "Fragment", Fragment, {}, { "default": () => $$render`${$$renderComponent($$result, "Fragment", Fragment, {}, { "default": () => $$render`${`<${Node.tag} ${stringifyAttributes(Node.attributes)}>`}` })}${Node.children.map((child) => $$render`${$$renderComponent($$result, "Astro.self", Astro.self, { "node": child })}`)}${$$renderComponent($$result, "Fragment", Fragment, {}, { "default": () => $$render`${`</${Node.tag}>`}` })}` })}`}`;
+	return $$render`${$$render`${$$renderComponent($$result, "Fragment", Fragment, {}, { "default": () => $$render`${$$renderComponent($$result, "Fragment", Fragment, {}, { "default": () => $$render`${$$unescapeHTML(`<${Node.tag} ${stringifyAttributes(Node.attributes)}>`)}` })}${Node.children.map((child) => $$render`${$$renderComponent($$result, "Astro.self", Astro.self, { "node": child })}`)}${$$renderComponent($$result, "Fragment", Fragment, {}, { "default": () => $$render`${$$unescapeHTML(`</${Node.tag}>`)}` })}` })}`}`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/define_vars_on_a_module_script_with_imports.astro
+++ b/crates/astro_codegen/tests/fixtures/define_vars_on_a_module_script_with_imports.astro
@@ -1,1 +1,2 @@
-<script type="module" define:vars={{foo:'bar'}}>import 'foo';\nvar three = foo;</script>
+<script type="module" define:vars={{foo:'bar'}}>import 'foo';
+var three = foo;</script>

--- a/crates/astro_codegen/tests/fixtures/define_vars_on_a_module_script_with_imports.snap
+++ b/crates/astro_codegen/tests/fixtures/define_vars_on_a_module_script_with_imports.snap
@@ -8,12 +8,10 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hydratedComponents: [],
 	clientOnlyComponents: [],
 	hydrationDirectives: new Set([]),
-	hoisted: [{
-		type: "inline",
-		value: `import 'foo';\\nvar three = foo;`
-	}]
+	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`<script>(function(){${$$defineScriptVars({ foo: "bar" })}import 'foo';\\nvar three = foo;})();<\/script>`;
+	return $$render`<script type="module">${$$defineScriptVars({ foo: "bar" })}import 'foo';
+var three = foo;<\/script>`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/define_vars_on_script_with_staticexpression_turned_on.snap
+++ b/crates/astro_codegen/tests/fixtures/define_vars_on_script_with_staticexpression_turned_on.snap
@@ -11,12 +11,9 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: [{
 		type: "inline",
 		value: `var two = "two";`
-	}, {
-		type: "inline",
-		value: `var three = foo;`
 	}]
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`<script>var one = 'one';<\/script>${$$renderScript($$result, "/src/pages/index.astro?astro&type=script&index=0&lang.ts")}<script>(function(){${$$defineScriptVars({ foo: "bar" })}var three = foo;})();<\/script><script>var four = foo;<\/script>`;
+	return $$render`<script>var one = 'one';<\/script>${$$renderScript($$result, "/src/pages/index.astro?astro&type=script&index=0&lang.ts")}<script>(function(){${$$defineScriptVars({ foo: "bar" })}var three = foo;})();<\/script><script>(function(){${$$defineScriptVars({ foo: "bar" })}var four = foo;})();<\/script>`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/no_extra_script_tag.snap
+++ b/crates/astro_codegen/tests/fixtures/no_extra_script_tag.snap
@@ -31,13 +31,23 @@ const $$Component = $$createComponent(($$result, $$props, $$slots) => {
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital@0;1&display=swap" rel="stylesheet">
 
 <!-- Scrollable a11y code helper -->
-<script type="module" src="/make-scrollable-code-focusable.js"><\/script><script>const root = document.documentElement;
+<script type="module" src="/make-scrollable-code-focusable.js"><\/script><script>
+  const root = document.documentElement;
   const theme = localStorage.getItem('theme');
   if (theme === 'dark' || (!theme) && window.matchMedia('(prefers-color-scheme: dark)').matches) {
     root.classList.add('theme-dark');
   } else {
     root.classList.remove('theme-dark');
   }
-<\/script>`;
+<\/script>
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-TEL60V1WM9"><\/script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-TEL60V1WM9');
+<\/script> -->`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/script_define_vars_i.snap
+++ b/crates/astro_codegen/tests/fixtures/script_define_vars_i.snap
@@ -8,10 +8,7 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hydratedComponents: [],
 	clientOnlyComponents: [],
 	hydrationDirectives: new Set([]),
-	hoisted: [{
-		type: "inline",
-		value: `console.log(value);`
-	}]
+	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
 	return $$render`<script>(function(){${$$defineScriptVars({ value: 0 })}console.log(value);})();<\/script>`;

--- a/crates/astro_codegen/tests/fixtures/script_define_vars_ii.snap
+++ b/crates/astro_codegen/tests/fixtures/script_define_vars_ii.snap
@@ -8,10 +8,7 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hydratedComponents: [],
 	clientOnlyComponents: [],
 	hydrationDirectives: new Set([]),
-	hoisted: [{
-		type: "inline",
-		value: `console.log(dashCase);`
-	}]
+	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
 	return $$render`<script>(function(){${$$defineScriptVars({ "dash-case": true })}console.log(dashCase);})();<\/script>`;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_component_with_quoted_attribute.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_component_with_quoted_attribute.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_on_component_with_quoted_attribute.astro
 ---
-import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$renderComponent($$result, "Component", Component, {}, { "default": () => $$render`${"content"}` })}`;
+	return $$render`${$$renderComponent($$result, "Component", Component, {}, { "default": () => $$render`${$$unescapeHTML("content")}` })}`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_component_with_template_literal_attribute_with_variable.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_component_with_template_literal_attribute_with_variable.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_on_component_with_template_literal_attribute_with_variable.astro
 ---
-import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$renderComponent($$result, "Component", Component, {}, { "default": () => $$render`${`${content}`}` })}`;
+	return $$render`${$$renderComponent($$result, "Component", Component, {}, { "default": () => $$render`${$$unescapeHTML(`${content}`)}` })}`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_component_with_template_literal_attribute_without_variable.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_component_with_template_literal_attribute_without_variable.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_on_component_with_template_literal_attribute_without_variable.astro
 ---
-import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$renderComponent($$result, "Component", Component, {}, { "default": () => $$render`${`content`}` })}`;
+	return $$render`${$$renderComponent($$result, "Component", Component, {}, { "default": () => $$render`${$$unescapeHTML(`content`)}` })}`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_custom-element_with_quoted_attribute.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_custom-element_with_quoted_attribute.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_on_custom-element_with_quoted_attribute.astro
 ---
-import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$renderComponent($$result, "custom-element", "custom-element", {}, { "default": () => $$render`${"content"}` })}`;
+	return $$render`${$$renderComponent($$result, "custom-element", "custom-element", {}, { "default": () => $$render`${$$unescapeHTML("content")}` })}`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_custom-element_with_template_literal_attribute_with_variable.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_custom-element_with_template_literal_attribute_with_variable.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_on_custom-element_with_template_literal_attribute_with_variable.astro
 ---
-import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$renderComponent($$result, "custom-element", "custom-element", {}, { "default": () => $$render`${`${content}`}` })}`;
+	return $$render`${$$renderComponent($$result, "custom-element", "custom-element", {}, { "default": () => $$render`${$$unescapeHTML(`${content}`)}` })}`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_custom-element_with_template_literal_attribute_without_variable.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_custom-element_with_template_literal_attribute_without_variable.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_on_custom-element_with_template_literal_attribute_without_variable.astro
 ---
-import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$renderComponent($$result, "custom-element", "custom-element", {}, { "default": () => $$render`${`content`}` })}`;
+	return $$render`${$$renderComponent($$result, "custom-element", "custom-element", {}, { "default": () => $$render`${$$unescapeHTML(`content`)}` })}`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_empty_tag_with_quoted_attribute.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_empty_tag_with_quoted_attribute.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_on_empty_tag_with_quoted_attribute.astro
 ---
-import { render as $$render, createComponent as $$createComponent, maybeRenderHead as $$maybeRenderHead, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { render as $$render, createComponent as $$createComponent, maybeRenderHead as $$maybeRenderHead, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$maybeRenderHead($$result)}<article>${"content"}</article>`;
+	return $$render`${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_fragment.astro
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_fragment.astro
@@ -1,1 +1,1 @@
-<Fragment set:html={"<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>"} />
+<Fragment set:html={"<p><i>This should be italic</i></p>"} />

--- a/crates/astro_codegen/tests/fixtures/set_html_on_fragment.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_fragment.snap
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$renderComponent($$result, "Fragment", Fragment, {}, { "default": () => $$render`${$$unescapeHTML("<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>")}` })}`;
+	return $$render`${$$renderComponent($$result, "Fragment", Fragment, {}, { "default": () => $$render`${$$unescapeHTML("<p><i>This should be italic</i></p>")}` })}`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_expression_template_literal_with_variable.astro
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_expression_template_literal_with_variable.astro
@@ -1,0 +1,1 @@
+<Fragment set:html={`<style>${dynamicCSS}</style>`} />

--- a/crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_expression_template_literal_with_variable.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_expression_template_literal_with_variable.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/astro_codegen/tests/snapshots.rs
-input_file: crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_template_literal_attribute_without_variable.astro
+input_file: crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_expression_template_literal_with_variable.astro
 ---
 import { Fragment, render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$renderComponent($$result, "Fragment", Fragment, {}, { "default": () => $$render`${$$unescapeHTML(`<p><i>This should be italic</i></p>`)}` })}`;
+	return $$render`${$$renderComponent($$result, "Fragment", Fragment, {}, { "default": () => $$render`${$$unescapeHTML(`<style>${dynamicCSS}</style>`)}` })}`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_quoted_attribute.astro
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_quoted_attribute.astro
@@ -1,1 +1,1 @@
-<Fragment set:html="<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>" />
+<Fragment set:html="<p><i>This should be italic</i></p>" />

--- a/crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_quoted_attribute.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_quoted_attribute.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_quoted_attribute.astro
 ---
-import { Fragment, render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { Fragment, render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$renderComponent($$result, "Fragment", Fragment, {}, { "default": () => $$render`${"<p><i>This should NOT be italic</i></p>"}` })}`;
+	return $$render`${$$renderComponent($$result, "Fragment", Fragment, {}, { "default": () => $$render`${$$unescapeHTML("<p><i>This should be italic</i></p>")}` })}`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_template_literal_attribute_with_variable.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_template_literal_attribute_with_variable.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_template_literal_attribute_with_variable.astro
 ---
-import { Fragment, render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { Fragment, render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$renderComponent($$result, "Fragment", Fragment, {}, { "default": () => $$render`${`${content}`}` })}`;
+	return $$render`${$$renderComponent($$result, "Fragment", Fragment, {}, { "default": () => $$render`${$$unescapeHTML(`${content}`)}` })}`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_template_literal_attribute_without_variable.astro
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_fragment_with_template_literal_attribute_without_variable.astro
@@ -1,1 +1,1 @@
-<Fragment set:html=`<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>` />
+<Fragment set:html=`<p><i>This should be italic</i></p>` />

--- a/crates/astro_codegen/tests/fixtures/set_html_on_script_with_quoted_attribute.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_script_with_quoted_attribute.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_on_script_with_quoted_attribute.astro
 ---
-import { render as $$render, createComponent as $$createComponent, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { render as $$render, createComponent as $$createComponent, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`<script>${"alert(1)"}<\/script>`;
+	return $$render`<script>${$$unescapeHTML("alert(1)")}<\/script>`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_self-closing_tag_with_quoted_attribute.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_self-closing_tag_with_quoted_attribute.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_on_self-closing_tag_with_quoted_attribute.astro
 ---
-import { render as $$render, createComponent as $$createComponent, maybeRenderHead as $$maybeRenderHead, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { render as $$render, createComponent as $$createComponent, maybeRenderHead as $$maybeRenderHead, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$maybeRenderHead($$result)}<article>${"content"}</article>`;
+	return $$render`${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_style_with_quoted_attribute.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_style_with_quoted_attribute.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_on_style_with_quoted_attribute.astro
 ---
-import { render as $$render, createComponent as $$createComponent, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { render as $$render, createComponent as $$createComponent, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`<style>${"h1{color:green;}"}</style>`;
+	return $$render`<style>${$$unescapeHTML("h1{color:green;}")}</style>`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_tag_with_children_and_quoted_attribute.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_tag_with_children_and_quoted_attribute.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_on_tag_with_children_and_quoted_attribute.astro
 ---
-import { render as $$render, createComponent as $$createComponent, maybeRenderHead as $$maybeRenderHead, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { render as $$render, createComponent as $$createComponent, maybeRenderHead as $$maybeRenderHead, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$maybeRenderHead($$result)}<article>${"content"}</article>`;
+	return $$render`${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_on_tag_with_empty_whitespace_and_quoted_attribute.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_on_tag_with_empty_whitespace_and_quoted_attribute.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_on_tag_with_empty_whitespace_and_quoted_attribute.astro
 ---
-import { render as $$render, createComponent as $$createComponent, maybeRenderHead as $$maybeRenderHead, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { render as $$render, createComponent as $$createComponent, maybeRenderHead as $$maybeRenderHead, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$maybeRenderHead($$result)}<article>${"content"}</article>`;
+	return $$render`${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_with_quoted_attribute.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_with_quoted_attribute.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_with_quoted_attribute.astro
 ---
-import { render as $$render, createComponent as $$createComponent, maybeRenderHead as $$maybeRenderHead, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { render as $$render, createComponent as $$createComponent, maybeRenderHead as $$maybeRenderHead, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$maybeRenderHead($$result)}<article>${"content"}</article>`;
+	return $$render`${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/set_html_with_quoted_attribute_and_other_attributes.snap
+++ b/crates/astro_codegen/tests/fixtures/set_html_with_quoted_attribute_and_other_attributes.snap
@@ -2,7 +2,7 @@
 source: crates/astro_codegen/tests/snapshots.rs
 input_file: crates/astro_codegen/tests/fixtures/set_html_with_quoted_attribute_and_other_attributes.astro
 ---
-import { render as $$render, createComponent as $$createComponent, maybeRenderHead as $$maybeRenderHead, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import { render as $$render, createComponent as $$createComponent, maybeRenderHead as $$maybeRenderHead, unescapeHTML as $$unescapeHTML, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
 	modules: [],
 	hydratedComponents: [],
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$maybeRenderHead($$result)}<article cool="true">${"content"}</article>`;
+	return $$render`${$$maybeRenderHead($$result)}<article cool="true">${$$unescapeHTML("content")}</article>`;
 }, undefined, undefined);
 export default $$Component;


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
