### PR TITLE
handle parenthesized conditional slots

### DIFF
--- a/.changeset/lazy-nights-unite.md
+++ b/.changeset/lazy-nights-unite.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/compiler-binding": patch
+"@astrojs/compiler-rs": patch
+---
+
+Fixes slots not working inside parenthesized conditional slots

--- a/crates/astro_codegen/src/printer/slots.rs
+++ b/crates/astro_codegen/src/printer/slots.rs
@@ -626,6 +626,9 @@ impl<'a> AstroCodegen<'a> {
                 self.add_source_mapping_for_span(arrow.span);
                 self.print_slot_aware_arrow_function(arrow);
             }
+            Expression::ParenthesizedExpression(paren) => {
+                self.print_conditional_slot_branch_expr(&paren.expression);
+            }
             Expression::ConditionalExpression(cond) => {
                 self.add_source_mapping_for_span(cond.span);
                 self.print_expression(&cond.test);
@@ -765,6 +768,9 @@ impl<'a> AstroCodegen<'a> {
                         self.print("`}");
                     }
                 }
+            }
+            Expression::ParenthesizedExpression(paren) => {
+                self.print_conditional_slot_branch(&paren.expression);
             }
             Expression::ConditionalExpression(cond) => {
                 // Nested ternary

--- a/crates/astro_codegen/tests/fixtures/nested_ternary_with_slots.astro
+++ b/crates/astro_codegen/tests/fixtures/nested_ternary_with_slots.astro
@@ -1,0 +1,6 @@
+---
+import Component from './Component.astro';
+---
+<Component>
+  {a ? (b ? <div slot="a">A</div> : <div slot="b">B</div>) : (c ? <div slot="c">C</div> : <div>Default</div>)}
+</Component>

--- a/crates/astro_codegen/tests/fixtures/nested_ternary_with_slots.snap
+++ b/crates/astro_codegen/tests/fixtures/nested_ternary_with_slots.snap
@@ -1,0 +1,22 @@
+---
+source: crates/astro_codegen/tests/snapshots.rs
+input_file: crates/astro_codegen/tests/fixtures/nested_ternary_with_slots.astro
+---
+import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, maybeRenderHead as $$maybeRenderHead, mergeSlots as $$mergeSlots, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import Component from "./Component.astro";
+import * as $$module1 from "./Component.astro";
+export const $$metadata = $$createMetadata(import.meta.url, {
+	modules: [{
+		module: $$module1,
+		specifier: "./Component.astro",
+		assert: {}
+	}],
+	hydratedComponents: [],
+	clientOnlyComponents: [],
+	hydrationDirectives: new Set([]),
+	hoisted: []
+});
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+	return $$render`${$$renderComponent($$result, "Component", Component, {}, $$mergeSlots({}, a ? b ? { "a": () => $$render`${$$maybeRenderHead($$result)}<div>A</div>` } : { "b": () => $$render`<div>B</div>` } : c ? { "c": () => $$render`<div>C</div>` } : { "default": () => $$render`<div>Default</div>` }))}`;
+}, undefined, undefined);
+export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/parenthesized_conditional_slots.astro
+++ b/crates/astro_codegen/tests/fixtures/parenthesized_conditional_slots.astro
@@ -1,0 +1,6 @@
+---
+import Component from './Component.astro';
+---
+<Component>
+  {(a ? <div slot="a">A</div> : <div slot="b">B</div>)}
+</Component>

--- a/crates/astro_codegen/tests/fixtures/parenthesized_conditional_slots.snap
+++ b/crates/astro_codegen/tests/fixtures/parenthesized_conditional_slots.snap
@@ -1,0 +1,22 @@
+---
+source: crates/astro_codegen/tests/snapshots.rs
+input_file: crates/astro_codegen/tests/fixtures/parenthesized_conditional_slots.astro
+---
+import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, maybeRenderHead as $$maybeRenderHead, mergeSlots as $$mergeSlots, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import Component from "./Component.astro";
+import * as $$module1 from "./Component.astro";
+export const $$metadata = $$createMetadata(import.meta.url, {
+	modules: [{
+		module: $$module1,
+		specifier: "./Component.astro",
+		assert: {}
+	}],
+	hydratedComponents: [],
+	clientOnlyComponents: [],
+	hydrationDirectives: new Set([]),
+	hoisted: []
+});
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+	return $$render`${$$renderComponent($$result, "Component", Component, {}, $$mergeSlots({}, a ? { "a": () => $$render`${$$maybeRenderHead($$result)}<div>A</div>` } : { "b": () => $$render`<div>B</div>` }))}`;
+}, undefined, undefined);
+export default $$Component;


### PR DESCRIPTION
## Changes                                                                                                                                                                                                    
                                                                                                                                                                                                             
### Problem

Parenthesized ternary expressions inside component slot children bypassed slot object generation for `$$mergeSlots`.

### Cause

The oxc parser wraps `(b ? x : y)` as `ParenthesizedExpression`. `print_conditional_slot_branch` had no match arm for it, so the `_ =>` fallback called `print_expression()` directly — skipping slot object wrapping.

### Fix

Added `Expression::ParenthesizedExpression` arm that unwraps and recurses                                                                           

Before:
```js                                                                                                                                                                                                                                                                                                                                                                                                                 
// {a ? (b ? <div slot="a">A</div> : <div slot="b">B</div>) : <div>Default</div>}
$$mergeSlots({},
  a
    ? b
      ? $$render`<div slot="a">A</div>`
      : $$render`<div slot="b">B</div>`
    : $$render`<div>Default</div>`
)                                                                          
```   
After:
```js                                                                                                                                                                                         
$$mergeSlots({},
  a
    ? b
      ? { "a": () => $$render`<div>A</div>` }
      : { "b": () => $$render`<div>B</div>` }
    : { "default": () => $$render`<div>Default</div>` }
)                                        
```                                                                                                                                                                                                             

## Testing                                                                                                                                                                                                    
   
- cargo test -p astro_codegen
- Added fixture nested_ternary_with_slots.astro                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                           
## Docs                                                                                                                                                                                                       
   
- Bug fix only            