### PR TITLE
collect slots inside optional chain expressions

### DIFF
--- a/.changeset/some-feet-smell.md
+++ b/.changeset/some-feet-smell.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/compiler-binding": patch
+"@astrojs/compiler-rs": patch
+---
+
+Fixes slots not being collected inside optional chain expressions

--- a/crates/astro_codegen/src/printer/slots.rs
+++ b/crates/astro_codegen/src/printer/slots.rs
@@ -187,7 +187,11 @@ fn collect_slots_from_expression<'a>(
             // Walk into callback arguments to find slotted JSX.
             collect_slots_from_call_arguments(&call.arguments, slots);
         }
-        _ => {}
+        _ => {
+            if let Some(inner) = expr.as_expression() {
+                collect_slots_from_inner_expression(inner, slots);
+            }
+        }
     }
 }
 
@@ -240,6 +244,13 @@ fn collect_slots_from_inner_expression<'a>(
             // e.g. items.map(item => <div slot="content">{item}</div>)
             // Walk into callback arguments to find slotted JSX.
             collect_slots_from_call_arguments(&call.arguments, slots);
+        }
+        Expression::ChainExpression(chain) => {
+            // e.g. items?.map(item => <div slot="item">{item}</div>)
+            // Unwrap the chain to reach the inner CallExpression.
+            if let oxc_ast::ast::ChainElement::CallExpression(call) = &chain.expression {
+                collect_slots_from_call_arguments(&call.arguments, slots);
+            }
         }
         _ => {}
     }

--- a/crates/astro_codegen/tests/fixtures/slots__optional_chain_.astro
+++ b/crates/astro_codegen/tests/fixtures/slots__optional_chain_.astro
@@ -1,0 +1,6 @@
+---
+import Component from './Component.astro';
+---
+<Component>
+  {items?.map(i => <div slot="item">{i}</div>)}
+</Component>

--- a/crates/astro_codegen/tests/fixtures/slots__optional_chain_.snap
+++ b/crates/astro_codegen/tests/fixtures/slots__optional_chain_.snap
@@ -1,0 +1,22 @@
+---
+source: crates/astro_codegen/tests/snapshots.rs
+input_file: crates/astro_codegen/tests/fixtures/slots__optional_chain_.astro
+---
+import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, maybeRenderHead as $$maybeRenderHead, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import Component from "./Component.astro";
+import * as $$module1 from "./Component.astro";
+export const $$metadata = $$createMetadata(import.meta.url, {
+	modules: [{
+		module: $$module1,
+		specifier: "./Component.astro",
+		assert: {}
+	}],
+	hydratedComponents: [],
+	clientOnlyComponents: [],
+	hydrationDirectives: new Set([]),
+	hoisted: []
+});
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+	return $$render`${$$renderComponent($$result, "Component", Component, {}, { "item": () => $$render`${items?.map((i) => $$render`${$$maybeRenderHead($$result)}<div>${i}</div>`)}` })}`;
+}, undefined, undefined);
+export default $$Component;


### PR DESCRIPTION
## Changed

Fixes slot collection for optional chaining expressions like:

```astro
<Component>
  {items?.map(i => <div slot="item">{i}</div>)}
</Component>
```

Previously, the `slot="item"` was ignored and everything went into the `"default"` slot.

Before:
```js
{ "default": () => $$render`${items?.map((i) => $$render`<div slot="item">${i}</div>`)}` }
```

After:
```js
{ "item": () => $$render`${items?.map((i) => $$render`<div>${i}</div>`)}` }
```

## Testing

- Added `slots__optional_chain_` fixture
- `cargo test -p astro_codegen` passes