### PR TITLE
fix(ci): add -x to x86_64-unknown-linux-gnu build for glibc compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           # -- Linux GNU --
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            build: pnpm run build --target x86_64-unknown-linux-gnu
+            build: pnpm run build --target x86_64-unknown-linux-gnu -x
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             build: pnpm run build --target aarch64-unknown-linux-gnu -x


### PR DESCRIPTION
## Changes

- Add `-x` flag to the `x86_64-unknown-linux-gnu` build command in CI, matching the pattern used by `aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`, and `aarch64-unknown-linux-musl`
- Without `-x`, the x64-gnu target builds natively on `ubuntu-latest` (glibc 2.39), linking the binary against the host glibc. The published binary requires glibc 2.35+, which breaks on Vercel (glibc 2.34) and Amazon Linux 2023.
- With `-x`, `cargo-zigbuild` pins glibc to 2.28

The upstream fix (napi-rs/napi-rs#3189) shipped in `@napi-rs/cli@3.6.1` (2026-04-08). This PR is now ready to merge.

## Testing

Verified on Vercel that the current binary fails with `GLIBC_2.35 not found` when loaded by Node.js on glibc 2.34. CI change only.

## Docs

Bug fix only.