### PR TITLE
fix(ci): use --use-napi-cross for linux-gnu targets

### DIFF
--- a/.changeset/fix-linux-gnu-glibc.md
+++ b/.changeset/fix-linux-gnu-glibc.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler-rs": patch
+---
+
+Fixed linux-gnu binaries requiring glibc 2.35+, which broke on Vercel, Amazon Linux 2023, and other environments with older glibc. Binaries now target glibc 2.17.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,10 +138,10 @@ jobs:
           # -- Linux GNU --
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            build: pnpm run build --target x86_64-unknown-linux-gnu -x
+            build: pnpm run build --target x86_64-unknown-linux-gnu --use-napi-cross
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            build: pnpm run build --target aarch64-unknown-linux-gnu -x
+            build: pnpm run build --target aarch64-unknown-linux-gnu --use-napi-cross
 
           # -- Linux musl --
           - host: ubuntu-latest
@@ -200,13 +200,13 @@ jobs:
           key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}
 
       - uses: mlugg/setup-zig@v2
-        if: ${{ contains(matrix.settings.target, 'linux') }}
+        if: ${{ contains(matrix.settings.target, 'musl') }}
         with:
           version: 0.15.2
 
       - name: Install cargo-zigbuild
         uses: taiki-e/install-action@v2
-        if: ${{ contains(matrix.settings.target, 'linux') }}
+        if: ${{ contains(matrix.settings.target, 'musl') }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Changes

Switches the `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` builds from `cargo-zigbuild` (via `-x`) to `@napi-rs/cross-toolchain` (via `--use-napi-cross`), matching the pattern used by [`@napi-rs/package-template`](https://github.com/napi-rs/package-template/blob/main/.github/workflows/CI.yml#L67), `oxc`, `@swc/core`, `@napi-rs/canvas`, and other major NAPI-RS projects.

Also narrows the `setup-zig` and `cargo-zigbuild` install steps to musl targets only, since gnu targets no longer need them.

## Why

The current binaries published by `@astrojs/compiler-binding-linux-x64-gnu@0.1.7` require `GLIBC_2.35`, which fails to load on:

- Vercel build containers (glibc 2.34)
- Amazon Linux 2023 (glibc 2.34)
- AWS Lambda Node.js runtimes
- RHEL/CentOS 7 (glibc 2.17)
- Debian 10 (glibc 2.28)

This happens because `cargo zigbuild` without an explicit glibc suffix (e.g. `.2.17`) falls back to zig 0.15's per-arch baseline, which is `GLIBC_2.35` on x86_64 and `GLIBC_2.30` on aarch64. The earlier switch to `-x` in #22 made the flag actually invoke zigbuild (previously silently skipped), but did not pin the glibc version, so the produced binaries still required a recent glibc.

`--use-napi-cross` downloads `@napi-rs/cross-toolchain`, which ships a sysroot pinned to glibc 2.17 for both architectures.

## Testing

Verified end to end on a fork by pushing this exact change to `feat/rust` and letting the full CI matrix run ([run 24626846498](https://github.com/ramonclaudio/compiler-rs/actions/runs/24626846498)). All 19 jobs passed, including `Test x86_64-unknown-linux-gnu - node@22` and `Test aarch64-unknown-linux-gnu - node@22` (the binaries load and run).

Downloaded the resulting `.node` artifacts and ran `objdump -T` on them:

| Target | Current (0.1.7, `-x`) | This PR (`--use-napi-cross`) |
|--|--|--|
| `x86_64-unknown-linux-gnu` | `GLIBC_2.35` | **`GLIBC_2.16`** |
| `aarch64-unknown-linux-gnu` | `GLIBC_2.30` | **`GLIBC_2.17`** |

`GLIBC_2.17` matches the floor used by `@swc/core` and makes the binaries load on RHEL 7 and newer.

Also verified live on Vercel (glibc 2.34) by vendoring the fixed binary into a test deployment with `experimental.rustCompiler: true`: the Rust compiler loads and builds all pages successfully. Same binary that fails with `GLIBC_2.35 not found` in production today.

## Docs

None needed. CI-only change.

## Prior context

- #22 added `-x` to the x64-gnu target, thinking that would fix the glibc issue. It turned out to be necessary but insufficient. This PR completes the fix.
- Related upstream fix: napi-rs/napi-rs#3189 (makes `-x` actually invoke zigbuild on native targets). That landed in `@napi-rs/cli@3.6.1`.
