### PR TITLE
fix: multiline component attributes

### DIFF
--- a/.changeset/fix-multiline-attribute-on-component.md
+++ b/.changeset/fix-multiline-attribute-on-component.md
@@ -3,4 +3,4 @@
 "@astrojs/compiler-rs": patch
 ---
 
-Fixes `Unterminated string literal` error when a quoted attribute on a component contains literal newlines (e.g. multi-line `class=""` produced by `prettier-plugin-classnames`).
+Fixes `Unterminated string literal` error when a quoted attribute on a component contains literal newlines (e.g. multi-line `class`).

--- a/.changeset/fix-multiline-attribute-on-component.md
+++ b/.changeset/fix-multiline-attribute-on-component.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/compiler-binding": patch
+"@astrojs/compiler-rs": patch
+---
+
+Fixes `Unterminated string literal` error when a quoted attribute on a component contains literal newlines (e.g. multi-line `class=""` produced by `prettier-plugin-classnames`).

--- a/crates/astro_codegen/src/printer/components.rs
+++ b/crates/astro_codegen/src/printer/components.rs
@@ -6,7 +6,7 @@
 
 use super::AstroCodegen;
 use super::elements::ScopeId;
-use super::escape::{decode_html_entities, escape_double_quotes};
+use super::escape::{decode_html_entities, escape_double_quotes, escape_newlines};
 use super::expr_to_string;
 use super::runtime;
 use super::whitespace::has_is_raw_attr;
@@ -441,7 +441,10 @@ impl<'a> AstroCodegen<'a> {
                                 if val.is_empty() {
                                     self.print(&format!("\"{sc}\""));
                                 } else {
-                                    self.print(&format!("\"{} {sc}\"", escape_double_quotes(val)));
+                                    self.print(&format!(
+                                        "\"{} {sc}\"",
+                                        escape_double_quotes(&escape_newlines(val))
+                                    ));
                                 }
                             }
                             Some(JSXAttributeValue::ExpressionContainer(expr)) => {
@@ -463,7 +466,7 @@ impl<'a> AstroCodegen<'a> {
                         }
                         Some(JSXAttributeValue::StringLiteral(lit)) => {
                             self.print("\"");
-                            self.print(&escape_double_quotes(lit.value.as_str()));
+                            self.print(&escape_double_quotes(&escape_newlines(lit.value.as_str())));
                             self.print("\"");
                         }
                         Some(JSXAttributeValue::ExpressionContainer(expr)) => {

--- a/crates/astro_codegen/src/printer/escape.rs
+++ b/crates/astro_codegen/src/printer/escape.rs
@@ -45,6 +45,16 @@ pub fn escape_single_quote(s: &str) -> String {
     s.cow_replace('\'', "\\'").into_owned()
 }
 
+/// Escape literal newlines (`\n`, `\r`) for embedding inside a JS string literal.
+///
+/// Quoted attribute values may legally contain raw newlines in HTML (e.g. from
+/// `prettier-plugin-classnames`), but those break a JS `"..."` string. Matches
+/// the Go compiler's `escapeNewlines`.
+pub fn escape_newlines(s: &str) -> String {
+    let s = s.cow_replace('\n', "\\n");
+    s.cow_replace('\r', "\\r").into_owned()
+}
+
 /// Escape a string for use as an HTML attribute value inside a template literal.
 ///
 /// Escapes template literal syntax (`` ` `` and `${`), HTML special characters
@@ -311,6 +321,37 @@ mod tests {
     #[test]
     fn single_quote_preserves_backslash() {
         assert_eq!(escape_single_quote("a\\b"), "a\\b");
+    }
+
+    // ---- escape_newlines ----
+
+    #[test]
+    fn newlines_basic() {
+        assert_eq!(escape_newlines("hello"), "hello");
+    }
+
+    #[test]
+    fn newlines_escapes_lf() {
+        assert_eq!(escape_newlines("a\nb"), "a\\nb");
+    }
+
+    #[test]
+    fn newlines_escapes_cr() {
+        assert_eq!(escape_newlines("a\rb"), "a\\rb");
+    }
+
+    #[test]
+    fn newlines_escapes_crlf() {
+        assert_eq!(escape_newlines("a\r\nb"), "a\\r\\nb");
+    }
+
+    #[test]
+    fn newlines_multiline_class() {
+        // The motivating case: prettier-plugin-classnames-style class attribute
+        assert_eq!(
+            escape_newlines("some-class\n  another-class\n  third-class"),
+            "some-class\\n  another-class\\n  third-class"
+        );
     }
 
     // ---- escape_html_attribute ----

--- a/crates/astro_codegen/tests/fixtures/multiline_class_attribute_on_component.astro
+++ b/crates/astro_codegen/tests/fixtures/multiline_class_attribute_on_component.astro
@@ -1,0 +1,3 @@
+<Component class="some-class
+  another-class
+  third-class">content</Component>

--- a/crates/astro_codegen/tests/fixtures/multiline_class_attribute_on_component.snap
+++ b/crates/astro_codegen/tests/fixtures/multiline_class_attribute_on_component.snap
@@ -1,0 +1,17 @@
+---
+source: crates/astro_codegen/tests/snapshots.rs
+assertion_line: 81
+input_file: crates/astro_codegen/tests/fixtures/multiline_class_attribute_on_component.astro
+---
+import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, createMetadata as $$createMetadata } from "http://localhost:3000/";
+export const $$metadata = $$createMetadata(import.meta.url, {
+	modules: [],
+	hydratedComponents: [],
+	clientOnlyComponents: [],
+	hydrationDirectives: new Set([]),
+	hoisted: []
+});
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+	return $$render`${$$renderComponent($$result, "Component", Component, { "class": "some-class\n  another-class\n  third-class" }, { "default": () => $$render`content` })}`;
+}, undefined, undefined);
+export default $$Component;


### PR DESCRIPTION
## Changes

Fixes an `Unterminated string literal` error when a **quoted attribute on a component** contains literal newlines — e.g. a multi-line `class=""` produced by `prettier-plugin-classnames`.

Component attributes are emitted into a JS props object (`{ "class": "..." }`). A raw `\n` inside that string literal is invalid JS and breaks the generated module.

- Add `escape_newlines` helper in `printer/escape.rs`, mirroring the Go compiler's `escapeNewlines` (`\n` → `\n`, `\r` → `\r`).
- Apply it alongside `escape_double_quotes` in the two component props-object paths in `components.rs`: the scoped-`class` merge and the general quoted-attribute case. Matches the Go compiler's single use of `escapeNewlines` in `printAttributesToObject`.

## Testing

- Unit tests for `escape_newlines` (LF, CR, CRLF, multi-line class, no-op).
- New snapshot fixture `multiline_class_attribute_on_component.astro` covering the motivating case.

## Docs

Bug fix only, no docs needed.
