### PR TITLE
fix: don't strip same-line whitespace

### DIFF
--- a/.changeset/jsx-compact-inline-whitespace.md
+++ b/.changeset/jsx-compact-inline-whitespace.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/compiler-binding": patch
+"@astrojs/compiler-rs": patch
+---
+
+Fixes `compact: 'jsx'` stripping significant same-line whitespace. JSX whitespace is now only trimmed where it borders a line break (matching React/Babel's rules), so a space at a text/expression, text/element, or element/element boundary is preserved. `<h1>Page {n}</h1>` now keeps its space (`Page 1`), as does `<span>hello</span> <em>world</em>`. Whitespace adjacent to newlines is still collapsed.

--- a/crates/astro_codegen/src/printer/whitespace.rs
+++ b/crates/astro_codegen/src/printer/whitespace.rs
@@ -23,8 +23,11 @@
 //!
 //! ## `CompactMode::Jsx`
 //!
-//! Strips all whitespace-only text nodes and all leading/trailing whitespace
-//! from text content. Interior whitespace runs are collapsed to a single space.
+//! Applies the React/JSX whitespace rules (Babel's `cleanJSXElementLiteralChild`):
+//! whitespace is trimmed only where it touches a line break. Whitespace within a
+//! single line is significant and preserved (leading or trailing space on a
+//! one-line text node, or a lone space between two elements). Whitespace-only
+//! lines are dropped, and the surviving lines are joined with a single space.
 
 use oxc_ast::ast::*;
 
@@ -126,26 +129,82 @@ pub(super) fn collapse_html(
 
 /// Apply `CompactMode::Jsx` whitespace collapsing to a text value.
 ///
-/// - Whitespace-only text → omitted (`None`).
-/// - Text with real content → leading and trailing whitespace stripped
-///   entirely; interior whitespace runs collapsed to a single space.
+/// Mirrors React/JSX text handling (Babel's `cleanJSXElementLiteralChild`):
+/// whitespace is only trimmed where it borders a line break. Within a single
+/// line, leading, trailing, and interior whitespace is significant and kept, so
+/// `Page ` and `: ` and a lone space between elements all survive. Tabs collapse
+/// to a single space, whitespace-only lines are dropped, and the surviving lines
+/// are joined with a single space. Returns `None` when nothing remains.
 pub(super) fn collapse_jsx(text: &str, in_raw_element: bool) -> Option<String> {
     if in_raw_element {
         return Some(text.to_string());
     }
 
-    if text.chars().all(|c| c.is_ascii_whitespace()) {
-        return None;
+    let lines = split_jsx_lines(text);
+    let line_count = lines.len();
+
+    // Index of the last line carrying a non-space/tab character; defaults to 0
+    // (matching Babel) so a single whitespace-only line is preserved verbatim.
+    let last_non_empty = lines
+        .iter()
+        .rposition(|line| line.bytes().any(|b| b != b' ' && b != b'\t'))
+        .unwrap_or(0);
+
+    let mut result = String::with_capacity(text.len());
+    for (i, line) in lines.iter().enumerate() {
+        let mut trimmed = line.replace('\t', " ");
+        if i != 0 {
+            trimmed = trimmed.trim_start_matches(' ').to_string();
+        }
+        if i + 1 != line_count {
+            trimmed = trimmed.trim_end_matches(' ').to_string();
+        }
+
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        result.push_str(&trimmed);
+        if i != last_non_empty {
+            result.push(' ');
+        }
     }
 
-    // Collapse all interior whitespace runs to a single space, then trim ends.
-    let collapsed: String = text.split_ascii_whitespace().collect::<Vec<_>>().join(" ");
-
-    if collapsed.is_empty() {
+    if result.is_empty() {
         None
     } else {
-        Some(collapsed)
+        Some(result)
     }
+}
+
+/// Split text on JSX line boundaries (`\r\n`, `\n`, or `\r`), keeping empty
+/// segments (including a trailing one after a final line break) so the line
+/// indices line up with React's `String.prototype.split(/\r\n|\n|\r/)`.
+fn split_jsx_lines(text: &str) -> Vec<&str> {
+    let bytes = text.as_bytes();
+    let mut lines = Vec::new();
+    let mut start = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\n' => {
+                lines.push(&text[start..i]);
+                i += 1;
+                start = i;
+            }
+            b'\r' => {
+                lines.push(&text[start..i]);
+                i += 1;
+                if i < bytes.len() && bytes[i] == b'\n' {
+                    i += 1;
+                }
+                start = i;
+            }
+            _ => i += 1,
+        }
+    }
+    lines.push(&text[start..]);
+    lines
 }
 
 #[cfg(test)]
@@ -229,22 +288,68 @@ mod tests {
 
     // --- Jsx mode ---
 
+    fn jsx(text: &str) -> Option<String> {
+        collapse_jsx(text, false)
+    }
+
+    // Same-line whitespace is significant and preserved (the bug these rules fix).
+
     #[test]
-    fn jsx_ws_only_removed() {
-        assert_eq!(collapse_jsx("   ", false), None);
-        assert_eq!(collapse_jsx("\n\t  ", false), None);
+    fn jsx_preserves_trailing_space_before_expression() {
+        // `<h1>Page {n}</h1>` → text node "Page "
+        assert_eq!(jsx("Page "), Some("Page ".to_string()));
     }
 
     #[test]
-    fn jsx_content_trimmed_and_collapsed() {
-        assert_eq!(
-            collapse_jsx("  hello world  ", false),
-            Some("hello world".to_string())
-        );
-        assert_eq!(
-            collapse_jsx("  hello   world  ", false),
-            Some("hello world".to_string())
-        );
+    fn jsx_preserves_space_between_expressions() {
+        // `<li>{id}: {title}</li>` → text node ": "
+        assert_eq!(jsx(": "), Some(": ".to_string()));
+    }
+
+    #[test]
+    fn jsx_preserves_leading_space() {
+        // `<h1 slot="named"> / Named</h1>` → text node " / Named"
+        assert_eq!(jsx(" / Named"), Some(" / Named".to_string()));
+    }
+
+    #[test]
+    fn jsx_preserves_lone_inter_element_space() {
+        // `<span>hello</span> <em>world</em>` → text node " " between elements
+        assert_eq!(jsx(" "), Some(" ".to_string()));
+        assert_eq!(jsx("   "), Some("   ".to_string()));
+    }
+
+    #[test]
+    fn jsx_preserves_interior_and_edge_spaces_on_single_line() {
+        assert_eq!(jsx("  hello world  "), Some("  hello world  ".to_string()));
+        assert_eq!(jsx("hello   world"), Some("hello   world".to_string()));
+    }
+
+    // Newline-adjacent whitespace is trimmed and collapsed (matches React).
+
+    #[test]
+    fn jsx_newline_only_text_removed() {
+        assert_eq!(jsx("\n"), None);
+        assert_eq!(jsx("\n\t  \n"), None);
+        assert_eq!(jsx("  \n  "), None);
+    }
+
+    #[test]
+    fn jsx_multiline_indented_text_collapses_to_single_spaces() {
+        assert_eq!(jsx("\n  Hello\n  world\n"), Some("Hello world".to_string()));
+    }
+
+    #[test]
+    fn jsx_trims_whitespace_touching_newline_but_keeps_inline_edge() {
+        // Leading space sits on the first line (kept); trailing newline is trimmed.
+        assert_eq!(jsx(" Hello\n"), Some(" Hello".to_string()));
+        // Leading newline is trimmed; trailing space sits on the last line (kept).
+        assert_eq!(jsx("\nHello "), Some("Hello ".to_string()));
+    }
+
+    #[test]
+    fn jsx_tabs_collapse_to_single_space() {
+        assert_eq!(jsx("a\tb"), Some("a b".to_string()));
     }
 
     #[test]
@@ -253,5 +358,55 @@ mod tests {
             collapse_jsx("  hello  ", true),
             Some("  hello  ".to_string())
         );
+        assert_eq!(
+            collapse_jsx("\n  keep me\n", true),
+            Some("\n  keep me\n".to_string())
+        );
+    }
+
+    /// Differential parity check: every `(input, expected)` pair below is the
+    /// verbatim output of Babel 7.29.0's `cleanJSXElementLiteralChild` run on the
+    /// same input. `collapse_jsx` must reproduce it exactly.
+    #[test]
+    fn jsx_matches_babel_clean_jsx_element_literal_child() {
+        let cases: &[(&str, Option<&str>)] = &[
+            ("Page ", Some("Page ")),
+            (": ", Some(": ")),
+            (" ", Some(" ")),
+            ("   ", Some("   ")),
+            (" / Named", Some(" / Named")),
+            ("Form result: ", Some("Form result: ")),
+            ("  hello world  ", Some("  hello world  ")),
+            ("hello   world", Some("hello   world")),
+            ("\n", None),
+            ("\n\t  \n", None),
+            ("  \n  ", None),
+            ("\n  Hello\n  world\n", Some("Hello world")),
+            (" Hello\n", Some(" Hello")),
+            ("\nHello ", Some("Hello ")),
+            ("a\tb", Some("a b")),
+            ("x\t\ty", Some("x  y")),
+            ("a \n b", Some("a b")),
+            ("a\r\nb", Some("a b")),
+            ("a\rb", Some("a b")),
+            ("\r\r", None),
+            ("  \n\thello\n  ", Some("hello")),
+            ("line1\n\n\nline2", Some("line1 line2")),
+            ("\t\thello\t\t", Some("  hello  ")),
+            ("end with spaces   \n", Some("end with spaces")),
+            ("中文 test", Some("中文 test")),
+            ("", None),
+            ("a\u{000b}b", Some("a\u{000b}b")),
+            ("one\ntwo\nthree", Some("one two three")),
+            ("  \n  x  \n  ", Some("x")),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(
+                collapse_jsx(input, false).as_deref(),
+                *expected,
+                "collapse_jsx({input:?}) diverged from Babel"
+            );
+        }
     }
 }

--- a/crates/astro_codegen/tests/fixtures/compact__jsx_inline_whitespace.astro
+++ b/crates/astro_codegen/tests/fixtures/compact__jsx_inline_whitespace.astro
@@ -1,0 +1,7 @@
+// @config compact=jsx
+<h1>Page {1}</h1>
+<li>{"post.md"}: {"Test Post"}</li>
+<p><span>hello</span> <em>world</em></p>
+<p>Form result: {3}</p>
+<div>   hello world   </div>
+<div>hello   world</div>

--- a/crates/astro_codegen/tests/fixtures/compact__jsx_inline_whitespace.snap
+++ b/crates/astro_codegen/tests/fixtures/compact__jsx_inline_whitespace.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/astro_codegen/tests/snapshots.rs
-input_file: crates/astro_codegen/tests/fixtures/compact__jsx_removes_whitespace_only.astro
+input_file: crates/astro_codegen/tests/fixtures/compact__jsx_inline_whitespace.astro
 ---
 import { render as $$render, createComponent as $$createComponent, maybeRenderHead as $$maybeRenderHead, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$maybeRenderHead($$result)}<div><span>hello</span></div><div></div>`;
+	return $$render`${$$maybeRenderHead($$result)}<h1>Page ${1}</h1><li>${"post.md"}: ${"Test Post"}</li><p><span>hello</span> <em>world</em></p><p>Form result: ${3}</p><div>   hello world   </div><div>hello   world</div>`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/compact__jsx_newline_whitespace.astro
+++ b/crates/astro_codegen/tests/fixtures/compact__jsx_newline_whitespace.astro
@@ -1,0 +1,11 @@
+// @config compact=jsx
+<p>
+  Hello
+  world
+</p>
+<div><span>a</span>
+<em>b</em></div>
+<ul>
+  <li>one</li>
+  <li>two</li>
+</ul>

--- a/crates/astro_codegen/tests/fixtures/compact__jsx_newline_whitespace.snap
+++ b/crates/astro_codegen/tests/fixtures/compact__jsx_newline_whitespace.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/astro_codegen/tests/snapshots.rs
-input_file: crates/astro_codegen/tests/fixtures/compact__jsx_strips_leading_trailing.astro
+input_file: crates/astro_codegen/tests/fixtures/compact__jsx_newline_whitespace.astro
 ---
 import { render as $$render, createComponent as $$createComponent, maybeRenderHead as $$maybeRenderHead, createMetadata as $$createMetadata } from "http://localhost:3000/";
 export const $$metadata = $$createMetadata(import.meta.url, {
@@ -11,6 +11,6 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hoisted: []
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-	return $$render`${$$maybeRenderHead($$result)}<div>hello world</div><div>hello world</div>`;
+	return $$render`${$$maybeRenderHead($$result)}<p>Hello world</p><div><span>a</span><em>b</em></div><ul><li>one</li><li>two</li></ul>`;
 }, undefined, undefined);
 export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/compact__jsx_removes_whitespace_only.astro
+++ b/crates/astro_codegen/tests/fixtures/compact__jsx_removes_whitespace_only.astro
@@ -1,3 +1,0 @@
-// @config compact=jsx
-<div>  <span>hello</span>  </div>
-<div>   </div>

--- a/crates/astro_codegen/tests/fixtures/compact__jsx_slot_inline_whitespace.astro
+++ b/crates/astro_codegen/tests/fixtures/compact__jsx_slot_inline_whitespace.astro
@@ -1,0 +1,4 @@
+// @config compact=jsx
+<Component>
+  <h1 slot="named"> / Named</h1>
+</Component>

--- a/crates/astro_codegen/tests/fixtures/compact__jsx_slot_inline_whitespace.snap
+++ b/crates/astro_codegen/tests/fixtures/compact__jsx_slot_inline_whitespace.snap
@@ -1,0 +1,16 @@
+---
+source: crates/astro_codegen/tests/snapshots.rs
+input_file: crates/astro_codegen/tests/fixtures/compact__jsx_slot_inline_whitespace.astro
+---
+import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, maybeRenderHead as $$maybeRenderHead, createMetadata as $$createMetadata } from "http://localhost:3000/";
+export const $$metadata = $$createMetadata(import.meta.url, {
+	modules: [],
+	hydratedComponents: [],
+	clientOnlyComponents: [],
+	hydrationDirectives: new Set([]),
+	hoisted: []
+});
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+	return $$render`${$$renderComponent($$result, "Component", Component, {}, { "named": () => $$render`${$$maybeRenderHead($$result)}<h1> / Named</h1>` })}`;
+}, undefined, undefined);
+export default $$Component;

--- a/crates/astro_codegen/tests/fixtures/compact__jsx_strips_leading_trailing.astro
+++ b/crates/astro_codegen/tests/fixtures/compact__jsx_strips_leading_trailing.astro
@@ -1,3 +1,0 @@
-// @config compact=jsx
-<div>   hello world   </div>
-<div>hello   world</div>


### PR DESCRIPTION
## Changes

Found while making it the default in Astro 7, compressHTML: `jsx` was unusable because it stripped a bunch of same-line whitespace it shouldn't have

## Testing

Updated and added tests

## Docs

N/A
