### PR TITLE
JSX in object literal transforms incorrectly

### DIFF
--- a/.changeset/sour-results-drum.md
+++ b/.changeset/sour-results-drum.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler-rs": patch
+---
+
+Fix handling JSX in object literal

--- a/crates/astro_codegen/src/printer/expressions.rs
+++ b/crates/astro_codegen/src/printer/expressions.rs
@@ -239,6 +239,19 @@ impl<'a> AstroCodegen<'a> {
                 self.print(&format!(" {} ", assign.operator.as_str()));
                 self.print_expression(&assign.right);
             }
+            Expression::StaticMemberExpression(member) => {
+                self.add_source_mapping_for_span(expr.span());
+                self.print_expression(&member.object);
+                self.print(if member.optional { "?." } else { "." });
+                self.print(member.property.name.as_str());
+            }
+            Expression::ComputedMemberExpression(member) => {
+                self.add_source_mapping_for_span(expr.span());
+                self.print_expression(&member.object);
+                self.print(if member.optional { "?.[" } else { "[" });
+                self.print_expression(&member.expression);
+                self.print("]");
+            }
             Expression::SequenceExpression(seq) => {
                 self.add_source_mapping_for_span(expr.span());
                 for (i, expr) in seq.expressions.iter().enumerate() {

--- a/crates/astro_codegen/src/printer/printer_tests.rs
+++ b/crates/astro_codegen/src/printer/printer_tests.rs
@@ -3033,3 +3033,26 @@ fn test_unquoted_hash_color_attribute() {
         "Unquoted hex colors should emit as quoted attributes, got:\n{output}"
     );
 }
+
+#[test]
+fn test_jsx_object_literal_lookup() {
+    let source = include_str!("../../tests/fixtures/jsx_object_literal_lookup.astro");
+    let output = compile_astro(source);
+
+    assert!(
+        !output.contains("main: <Widget />"),
+        "JSX object literal values should be transformed, got:\n{output}"
+    );
+    assert!(
+        output.contains("$$renderComponent"),
+        "Expected transformed JSX in object literal lookup, got:\n{output}"
+    );
+
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &output, SourceType::mjs()).parse();
+    assert!(
+        parsed.errors.is_empty(),
+        "Generated module is not valid JS: {:?}",
+        parsed.errors
+    );
+}

--- a/crates/astro_codegen/tests/fixtures/jsx_object_literal_lookup.astro
+++ b/crates/astro_codegen/tests/fixtures/jsx_object_literal_lookup.astro
@@ -1,0 +1,16 @@
+---
+import Widget from './Widget.astro';
+---
+
+<html>
+  <body>
+    {(layer = 'main') => ({
+      main: (
+        <Widget />
+      ),
+      other: (
+        <p>Other layer</p>
+      ),
+    }[layer])}
+  </body>
+</html>

--- a/crates/astro_codegen/tests/fixtures/jsx_object_literal_lookup.snap
+++ b/crates/astro_codegen/tests/fixtures/jsx_object_literal_lookup.snap
@@ -1,0 +1,29 @@
+---
+source: crates/astro_codegen/tests/snapshots.rs
+input_file: crates/astro_codegen/tests/fixtures/jsx_object_literal_lookup.astro
+---
+import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, maybeRenderHead as $$maybeRenderHead, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import Widget from "./Widget.astro";
+import * as $$module1 from "./Widget.astro";
+export const $$metadata = $$createMetadata(import.meta.url, {
+	modules: [{
+		module: $$module1,
+		specifier: "./Widget.astro",
+		assert: {}
+	}],
+	hydratedComponents: [],
+	clientOnlyComponents: [],
+	hydrationDirectives: new Set([]),
+	hoisted: []
+});
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+	return $$render`<html>
+  ${$$maybeRenderHead($$result)}<body>
+    ${(layer = "main") => ({
+		main: $$render`${$$renderComponent($$result, "Widget", Widget, {})}`,
+		other: $$render`<p>Other layer</p>`
+	})[layer]}
+  </body>
+</html>`;
+}, undefined, undefined);
+export default $$Component;


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/17198
- Transforms object literals so as to allow JSX expressions

## Testing

Added `crates/astro_codegen/src/printer/printer_tests.rs:fn test_jsx_object_literal_lookup` in commit https://github.com/someonewithpc/compiler-rs/commit/ef273608426287491d1adc5b7bc1a0c460bc0d52 and ran `cargo test -p astro_codegen`

## Docs

As far as I can tell, it doesn't affect documentation. Bug fix only