### PR TITLE
fix(client:only): keep import when binding is referenced elsewhere

### DIFF
--- a/.changeset/client-only-import-stripping.md
+++ b/.changeset/client-only-import-stripping.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler-rs": patch
+---
+
+Fixes `client:only` causing a component's import to be stripped when the same binding is still used elsewhere, such as another plain instance, a `<Scope.Component>` sharing the import, or a reference in the frontmatter.

--- a/crates/astro_codegen/src/printer/mod.rs
+++ b/crates/astro_codegen/src/printer/mod.rs
@@ -979,16 +979,13 @@ impl<'a> AstroCodegen<'a> {
                                             s.local.name.as_str()
                                         }
                                     };
-                                    // Must be in client_only_component_names AND NOT in
-                                    // hydrated_components (which tracks non-client:only usage)
                                     self.scan_result
                                         .client_only_component_names
                                         .contains(local_name)
                                         && !self
                                             .scan_result
-                                            .hydrated_components
-                                            .iter()
-                                            .any(|c| c.name == local_name)
+                                            .referenced_bindings
+                                            .contains(local_name)
                                 })
                         } else {
                             false

--- a/crates/astro_codegen/src/printer/printer_tests.rs
+++ b/crates/astro_codegen/src/printer/printer_tests.rs
@@ -2644,6 +2644,104 @@ import { CompA, CompB } from 'test';
     );
 }
 
+#[test]
+fn test_client_only_import_kept_when_also_used_plainly() {
+    let source = r"---
+import MyComp from 'test';
+---
+<MyComp client:only='react' />
+<MyComp />";
+    let output = compile_astro(source);
+    assert!(
+        output.contains("import MyComp from \"test\""),
+        "import needed for plain usage must NOT be suppressed: {output}"
+    );
+}
+
+#[test]
+fn test_client_only_import_kept_when_also_used_with_client_load() {
+    let source = r"---
+import MyComp from 'test';
+---
+<MyComp client:only='react' />
+<MyComp client:load />";
+    let output = compile_astro(source);
+    assert!(
+        output.contains("import MyComp from \"test\""),
+        "import needed for client:load usage must NOT be suppressed: {output}"
+    );
+}
+
+#[test]
+fn test_client_only_namespace_import_kept_when_member_used_plainly() {
+    let source = r"---
+import * as Scope from 'test';
+---
+<Scope.Foo client:only='react' />
+<Scope.Bar />";
+    let output = compile_astro(source);
+    assert!(
+        output.contains("import * as Scope from \"test\""),
+        "namespace import needed for Scope.Bar must NOT be suppressed: {output}"
+    );
+}
+
+#[test]
+fn test_client_only_namespace_import_suppressed_when_member_exclusive() {
+    let source = r"---
+import * as Scope from 'test';
+---
+<Scope.Foo client:only='react' />";
+    let output = compile_astro(source);
+    assert!(
+        !output.contains("import * as Scope from \"test\""),
+        "exclusively-client:only namespace import must be suppressed: {output}"
+    );
+}
+
+#[test]
+fn test_client_only_import_kept_when_referenced_in_frontmatter() {
+    let source = r"---
+import MyComp from 'test';
+const also = MyComp;
+---
+<MyComp client:only='react' />";
+    let output = compile_astro(source);
+    assert!(
+        output.contains("import MyComp from \"test\""),
+        "import referenced in frontmatter must NOT be suppressed: {output}"
+    );
+}
+
+#[test]
+fn test_client_only_import_kept_when_referenced_in_attribute_expression() {
+    // The binding is referenced in the client:only element's own props, which are
+    // built server-side, so the import must survive.
+    let source = r"---
+import MyComp from 'test';
+---
+<MyComp client:only='react' label={MyComp.label} />";
+    let output = compile_astro(source);
+    assert!(
+        output.contains("import MyComp from \"test\""),
+        "import referenced in an attribute expression must NOT be suppressed: {output}"
+    );
+}
+
+#[test]
+fn test_client_only_import_kept_when_referenced_in_template_expression() {
+    let source = r"---
+import MyComp from 'test';
+---
+<MyComp client:only='react' />
+{MyComp.displayName}";
+    let output = compile_astro(source);
+    assert!(
+        output.contains("import MyComp from \"test\""),
+        "import referenced in a template expression must NOT be suppressed: {output}"
+    );
+}
+
 // -------------------------------------------------------------------------
 // transition:persist tests
 // -------------------------------------------------------------------------

--- a/crates/astro_codegen/src/scanner.rs
+++ b/crates/astro_codegen/src/scanner.rs
@@ -37,6 +37,11 @@ pub struct ScanResult {
     /// Set of component names (or namespace roots) that use `client:only`.
     /// Used by the printer to detect client:only imports during frontmatter processing.
     pub client_only_component_names: FxHashSet<String>,
+    /// Roots of import bindings referenced anywhere the reference survives to the
+    /// output: non-`client:only` component instances, frontmatter code, and
+    /// template/attribute expressions. A `client:only` import is only safe to strip
+    /// if its binding root is absent here.
+    pub referenced_bindings: FxHashSet<String>,
     /// Collected hydrated components for metadata
     pub hydrated_components: Vec<HydratedComponent>,
     /// Collected client-only components with full names (including dot-notation)
@@ -70,6 +75,8 @@ pub struct AstroScanner<'a> {
     has_await: bool,
     /// Set of component names that use `client:only`
     client_only_component_names: FxHashSet<String>,
+    /// Roots of import bindings referenced anywhere that survives to output
+    referenced_bindings: FxHashSet<String>,
     /// Collected hydrated components
     hydrated_components: Vec<HydratedComponent>,
     /// Collected client-only components (full names including dot-notation)
@@ -93,6 +100,7 @@ impl<'a> AstroScanner<'a> {
             has_template_element: false,
             has_await: false,
             client_only_component_names: FxHashSet::default(),
+            referenced_bindings: FxHashSet::default(),
             hydrated_components: Vec::new(),
             client_only_components: Vec::new(),
             server_deferred_components: Vec::new(),
@@ -110,6 +118,7 @@ impl<'a> AstroScanner<'a> {
             uses_transitions: self.uses_transitions,
             has_await: self.has_await,
             client_only_component_names: self.client_only_component_names,
+            referenced_bindings: self.referenced_bindings,
             hydrated_components: self.hydrated_components,
             client_only_components: self.client_only_components,
             server_deferred_components: self.server_deferred_components,
@@ -124,6 +133,8 @@ impl<'a> AstroScanner<'a> {
         let name = get_jsx_element_name(&el.name);
         let is_component = is_component_name(&name);
         let is_custom = is_custom_element(&name);
+        let component_root = name.split('.').next().unwrap_or(&name).to_string();
+        let mut node_is_client_only = false;
 
         for attr in &el.attributes {
             if let JSXAttributeItem::Attribute(attr) = attr {
@@ -154,6 +165,7 @@ impl<'a> AstroScanner<'a> {
                 // Detect client:* directives
                 if let Some(directive) = attr_name.strip_prefix("client:") {
                     if directive == "only" {
+                        node_is_client_only = true;
                         // Store the namespace root (or simple name) for import-level checks
                         if name.contains('.') {
                             if let Some(namespace) = name.split('.').next() {
@@ -191,6 +203,11 @@ impl<'a> AstroScanner<'a> {
                     break; // Only process first client:* directive
                 }
             }
+        }
+
+        // A non-client:only instance needs its import for SSR, even when the binding is also used with client:only.
+        if (is_component || is_custom) && !node_is_client_only {
+            self.referenced_bindings.insert(component_root);
         }
     }
 
@@ -311,7 +328,22 @@ impl<'a> Visit<'a> for AstroScanner<'a> {
         if ident.name == "Astro" {
             self.uses_astro_global = true;
         }
+        // Every surviving reference (frontmatter, expressions, attribute values, and
+        // non-client:only tag names) keeps its binding's import alive.
+        self.referenced_bindings.insert(ident.name.to_string());
     }
+
+    fn visit_jsx_opening_element(&mut self, el: &JSXOpeningElement<'a>) {
+        // A client:only tag emits `null`, not the binding, so its name isn't a
+        // reference; attributes still are (their expressions can reference bindings).
+        if !opening_element_has_client_only(el) {
+            self.visit_jsx_element_name(&el.name);
+        }
+        self.visit_jsx_attribute_items(&el.attributes);
+    }
+
+    // Closing tag names never emit a standalone reference.
+    fn visit_jsx_closing_element(&mut self, _el: &JSXClosingElement<'a>) {}
 
     /// Process JSX elements for directives and script hoisting.
     fn visit_jsx_element(&mut self, el: &JSXElement<'a>) {
@@ -414,6 +446,12 @@ pub fn is_component_name(name: &str) -> bool {
 
 pub fn is_custom_element(name: &str) -> bool {
     name.contains('-')
+}
+
+fn opening_element_has_client_only(el: &JSXOpeningElement<'_>) -> bool {
+    el.attributes.iter().any(|attr| {
+        matches!(attr, JSXAttributeItem::Attribute(a) if get_jsx_attribute_name(&a.name) == "client:only")
+    })
 }
 
 /// Returns `true` if a `<script>` element should be hoisted (bundled via


### PR DESCRIPTION
## Changes

Previously if a component was referred to as client:only, we'd remove its import always. This is typically fine, however a component can, in some niche situations, be both referred as client:only and not. This PR now detects this and keep the import correctly.

## Testing

Added tests

## Docs

N/A
