### PR TITLE
fix(slots): group same-named direct and expression slots into one key

### DIFF
--- a/.changeset/slots-same-named-direct-and-expression.md
+++ b/.changeset/slots-same-named-direct-and-expression.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler-rs": patch
+---
+
+Fixes a direct element and an expression slot targeting the same named slot, such as `<div slot="x">A</div>{b && <div slot="x">B</div>}`, rendering only the last one. Both now render into the slot, matching same-named expression slots.

--- a/crates/astro_codegen/src/printer/printer_tests.rs
+++ b/crates/astro_codegen/src/printer/printer_tests.rs
@@ -192,6 +192,46 @@ import Component from "test";
 }
 
 #[test]
+fn test_slot_same_named_direct_and_expression_group_into_one_key() {
+    // A direct element and an expression slot with the same name render under a
+    // single slot key (bodies concatenated), not a duplicate object key where JS
+    // drops all but the last. Matches how same-named expression slots already
+    // group, and the Go compiler.
+    let source = r#"---
+import Component from "test";
+---
+<Component><div slot="x">A</div>{b && <div slot="x">B</div>}</Component>"#;
+    let output = compile_astro(source);
+
+    assert!(
+        output.matches("\"x\":").count() == 1,
+        "Mixed direct and expression slots should produce one slot key, not duplicates: {output}"
+    );
+    assert!(
+        output.contains("<div>A</div>") && output.contains("b &&"),
+        "Both the direct element and the branch body should survive in the merged slot: {output}"
+    );
+}
+
+#[test]
+fn test_slot_same_named_mixed_keeps_source_order() {
+    // The merged slot body concatenates siblings in source order, so an expression
+    // slot authored before a direct element renders before it.
+    let source = r#"---
+import Component from "test";
+---
+<Component>{b && <div slot="x">B</div>}<div slot="x">A</div></Component>"#;
+    let output = compile_astro(source);
+
+    let expr_pos = output.find("b &&").expect("expression slot missing");
+    let direct_pos = output.find("<div>A</div>").expect("direct element missing");
+    assert!(
+        expr_pos < direct_pos,
+        "Merged slot body should keep source order (expression before direct element): {output}"
+    );
+}
+
+#[test]
 fn test_client_load_directive() {
     let source = r"---
 import Component from 'test';

--- a/crates/astro_codegen/src/printer/slots.rs
+++ b/crates/astro_codegen/src/printer/slots.rs
@@ -409,12 +409,14 @@ impl<'a> AstroCodegen<'a> {
     pub(super) fn print_component_slots(&mut self, children: &[JSXChild<'a>]) {
         // Categorize children into:
         // 1. default_children — children without slot attribute
-        // 2. named_slots — direct elements with slot="name"
-        // 3. expression_slots — expressions containing single slotted element
-        // 4. conditional_slots — expressions with multiple different slots (need $$mergeSlots)
+        // 2. named_slots — single static slot="name", whether a direct element or
+        //    expression-wrapped (`{cond && <div slot="name">}`)
+        // 3. conditional_slots — expressions with multiple different slots (need $$mergeSlots)
         let mut default_children: Vec<&JSXChild<'a>> = Vec::new();
+        // Direct and expression-wrapped elements share this bucket, keyed by name, so a
+        // plain `slot="x"` and a `{cond && <_ slot="x">}` sibling don't emit a duplicate
+        // (last-wins) object key. Matches the Go compiler.
         let mut named_slots: Vec<(String, Vec<&JSXChild<'a>>)> = Vec::new();
-        let mut expression_slots: Vec<(&str, Vec<&JSXChild<'a>>)> = Vec::new();
         let mut conditional_slots: Vec<&JSXExpressionContainer<'a>> = Vec::new();
 
         // Direct elements with slot={expr} (e.g. <Comp slot={name} />)
@@ -459,15 +461,14 @@ impl<'a> AstroCodegen<'a> {
                             default_children.push(child);
                         }
                         ExpressionSlotInfo::Single(slot_name) => {
-                            // Group same-named expression slots so siblings don't emit
-                            // a duplicate (last-wins) object key.
-                            if let Some((_, slot_children)) = expression_slots
-                                .iter_mut()
-                                .find(|(name, _)| *name == slot_name)
+                            // Group with direct-element slots of the same name so siblings
+                            // don't emit a duplicate (last-wins) object key.
+                            if let Some((_, slot_children)) =
+                                named_slots.iter_mut().find(|(name, _)| name == slot_name)
                             {
                                 slot_children.push(child);
                             } else {
-                                expression_slots.push((slot_name, vec![child]));
+                                named_slots.push((slot_name.to_string(), vec![child]));
                             }
                         }
                         ExpressionSlotInfo::SingleDynamic(expr_str, span) => {
@@ -530,7 +531,8 @@ impl<'a> AstroCodegen<'a> {
             self.print("`,");
         }
 
-        // Print named slots (direct elements with slot attribute)
+        // Print named slots — direct and expression-wrapped elements sharing a name
+        // render under one key, bodies concatenated, like the default slot's children.
         for (name, slot_children) in &named_slots {
             self.print("\"");
             self.print(&escape_double_quotes(name));
@@ -540,21 +542,6 @@ impl<'a> AstroCodegen<'a> {
             let prev = self.skip_slot_attribute;
             self.skip_slot_attribute = true;
             self.print_slot_children(slot_children);
-            self.skip_slot_attribute = prev;
-            self.print("`,");
-        }
-
-        // Print expression slots (expressions containing a single slotted element)
-        for (name, slot_children) in &expression_slots {
-            self.print("\"");
-            self.print(&escape_double_quotes(name));
-            self.print("\": ");
-            self.print_slot_fn_open(AwaitDetector::found_in_refs(slot_children));
-            let prev = self.skip_slot_attribute;
-            self.skip_slot_attribute = true;
-            for child in slot_children {
-                self.print_jsx_child(child);
-            }
             self.skip_slot_attribute = prev;
             self.print("`,");
         }


### PR DESCRIPTION
## Changes

Two elements targeting the same named slot would only render the last one when one was a plain element and the other was wrapped in an expression, like `<div slot="x">A</div>{cond && <div slot="x">B</div>}`. #64 fixed this for two expression-wrapped elements; this handles the mixed case too. Both now render.

Fixes withastro/astro#17266

## Testing

Added tests

## Docs

N/A
