### PR TITLE
fix(scripts): keep empty scripts index-aligned with renderScript calls

### DIFF
--- a/.changeset/empty-script-index-alignment.md
+++ b/.changeset/empty-script-index-alignment.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler-rs": patch
+---
+
+Fixes empty script tags (i.e. `<script></script>`) causing the build to fail

--- a/crates/astro_codegen/src/printer/mod.rs
+++ b/crates/astro_codegen/src/printer/mod.rs
@@ -17,7 +17,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::options::CompactMode;
 use crate::scanner::{
     AstroScanner, ScanResult, get_jsx_attribute_name, get_jsx_element_name, is_component_name,
-    is_custom_element, should_hoist_script,
+    is_custom_element, is_extracted_hoisted_script,
 };
 use crate::{SourcemapOption, TransformOptions};
 use whitespace::{TextPosition, collapse_html, collapse_jsx};
@@ -1524,27 +1524,7 @@ impl<'a> AstroCodegen<'a> {
         }
 
         // Handle <script> elements that should be hoisted
-        let is_hoisted_script = should_hoist_script(&el.opening_element.attributes)
-            && (el
-                .children
-                .iter()
-                .any(|child| matches!(child, JSXChild::AstroScript(_)))
-                || el.children.iter().any(|child| {
-                    if let JSXChild::Text(text) = child {
-                        !text.value.trim().is_empty()
-                    } else {
-                        false
-                    }
-                })
-                || el.opening_element.attributes.iter().any(|attr| {
-                    if let JSXAttributeItem::Attribute(attr) = attr {
-                        get_jsx_attribute_name(&attr.name) == "src"
-                    } else {
-                        false
-                    }
-                }));
-
-        if name == "script" && !self.in_non_hoistable && is_hoisted_script {
+        if name == "script" && !self.in_non_hoistable && is_extracted_hoisted_script(el) {
             self.add_source_mapping_for_span(el.opening_element.span);
 
             let filename = self

--- a/crates/astro_codegen/src/printer/printer_tests.rs
+++ b/crates/astro_codegen/src/printer/printer_tests.rs
@@ -2489,6 +2489,43 @@ fn test_script_src_with_data_attr_not_hoisted() {
     );
 }
 
+#[test]
+fn test_empty_script_gets_hoisted_slot() {
+    // Empty script still emits renderScript index=0, so it must occupy metadata slot 0.
+    let output = compile_astro("<script></script>");
+
+    assert!(
+        output.contains("index=0"),
+        "empty script must still emit renderScript at index 0: {output}"
+    );
+    assert!(
+        output.contains("type: \"inline\""),
+        "empty script must occupy a hoisted metadata slot: {output}"
+    );
+}
+
+#[test]
+fn test_empty_then_real_script_indices_stay_aligned() {
+    // Regression: a leading empty script must not shift the real script off index 1.
+    let output = compile_astro("<script></script>\n<script>console.log(2)</script>");
+
+    assert!(
+        output.contains("index=0") && output.contains("index=1"),
+        "both scripts must emit renderScript calls: {output}"
+    );
+    let hoisted_start = output.find("hoisted:").expect("hoisted array present");
+    let hoisted = &output[hoisted_start..];
+    let inline_count = hoisted.matches("type: \"inline\"").count();
+    assert_eq!(
+        inline_count, 2,
+        "hoisted array must have one slot per renderScript index (index 0 empty, index 1 real): {output}"
+    );
+    assert!(
+        hoisted.contains("console.log(2)"),
+        "the real script must remain in the hoisted array: {output}"
+    );
+}
+
 // -------------------------------------------------------------------------
 // set:html must always use $$unescapeHTML (including template literals)
 // -------------------------------------------------------------------------

--- a/crates/astro_codegen/src/printer/printer_tests.rs
+++ b/crates/astro_codegen/src/printer/printer_tests.rs
@@ -2491,7 +2491,6 @@ fn test_script_src_with_data_attr_not_hoisted() {
 
 #[test]
 fn test_empty_script_gets_hoisted_slot() {
-    // Empty script still emits renderScript index=0, so it must occupy metadata slot 0.
     let output = compile_astro("<script></script>");
 
     assert!(
@@ -2506,7 +2505,6 @@ fn test_empty_script_gets_hoisted_slot() {
 
 #[test]
 fn test_empty_then_real_script_indices_stay_aligned() {
-    // Regression: a leading empty script must not shift the real script off index 1.
     let output = compile_astro("<script></script>\n<script>console.log(2)</script>");
 
     assert!(

--- a/crates/astro_codegen/src/scanner.rs
+++ b/crates/astro_codegen/src/scanner.rs
@@ -211,16 +211,10 @@ impl<'a> AstroScanner<'a> {
         }
     }
 
-    /// Check if a <script> element should be hoisted and collect it.
+    /// Pushes exactly one metadata entry (an empty inline entry for a
+    /// content-less script), keeping indices aligned with the printer's
+    /// `$$renderScript` calls. Callers must gate on [`is_extracted_hoisted_script`].
     fn try_collect_script(&mut self, el: &JSXElement<'a>) {
-        let name = get_jsx_element_name(&el.opening_element.name);
-        if name != "script" {
-            return;
-        }
-        if !should_hoist_script(&el.opening_element.attributes) {
-            return;
-        }
-
         let attrs: Vec<_> = el.opening_element.attributes.iter().collect();
 
         // Try AstroScript child first (parsed JS/TS content)
@@ -268,13 +262,11 @@ impl<'a> AstroScanner<'a> {
             self.push_external_script(src);
         } else {
             let content = get_script_content(self.allocator, program);
-            if !content.is_empty() {
-                self.hoisted_scripts.push(TransformResultHoistedScript {
-                    script_type: HoistedScriptType::Inline,
-                    code: Some(content),
-                    src: None,
-                });
-            }
+            self.hoisted_scripts.push(TransformResultHoistedScript {
+                script_type: HoistedScriptType::Inline,
+                code: Some(content),
+                src: None,
+            });
         }
     }
 
@@ -299,14 +291,11 @@ impl<'a> AstroScanner<'a> {
                 .collect::<Vec<_>>()
                 .join("");
 
-            let content = content.trim();
-            if !content.is_empty() {
-                self.hoisted_scripts.push(TransformResultHoistedScript {
-                    script_type: HoistedScriptType::Inline,
-                    code: Some(content.to_string()),
-                    src: None,
-                });
-            }
+            self.hoisted_scripts.push(TransformResultHoistedScript {
+                script_type: HoistedScriptType::Inline,
+                code: Some(content.trim().to_string()),
+                src: None,
+            });
         }
     }
 }
@@ -349,7 +338,7 @@ impl<'a> Visit<'a> for AstroScanner<'a> {
         // Check for hoistable scripts — if we collect one, skip walking
         // children to avoid visit_astro_script double-collecting the same script.
         if name == "script" {
-            if !self.in_non_hoistable && should_hoist_script(&el.opening_element.attributes) {
+            if !self.in_non_hoistable && is_extracted_hoisted_script(el) {
                 self.try_collect_script(el);
             }
             // Don't walk children for any <script> element — AstroScript children
@@ -487,6 +476,24 @@ pub fn should_hoist_script(attrs: &oxc_allocator::Vec<'_, JSXAttributeItem<'_>>)
 
     // Scripts with no attributes at all, or with just `type="module"`, are hoistable.
     attrs.is_empty() || (has_type_module && !has_other)
+}
+
+/// Returns `true` if a `<script>` is extracted and emitted via `$$renderScript`.
+/// Shared by the scanner (collects the metadata entry) and the printer (emits the
+/// call) so they can't disagree — a mismatch shifts indices and makes
+/// `$$renderScript` resolve to the wrong or a missing script at runtime.
+pub fn is_extracted_hoisted_script(el: &JSXElement<'_>) -> bool {
+    should_hoist_script(&el.opening_element.attributes)
+        && (el
+            .children
+            .iter()
+            .any(|child| matches!(child, JSXChild::AstroScript(_)))
+            || el.children.iter().any(|child| {
+                matches!(child, JSXChild::Text(text) if !text.value.trim().is_empty())
+            })
+            || el.opening_element.attributes.iter().any(|attr| {
+                matches!(attr, JSXAttributeItem::Attribute(attr) if get_jsx_attribute_name(&attr.name) == "src")
+            }))
 }
 
 /// Get the script content as a string by codegen-ing the program.

--- a/crates/astro_codegen/tests/fixtures/mayberenderhead_not_printed_for_hoisted_scripts.snap
+++ b/crates/astro_codegen/tests/fixtures/mayberenderhead_not_printed_for_hoisted_scripts.snap
@@ -8,7 +8,10 @@ export const $$metadata = $$createMetadata(import.meta.url, {
 	hydratedComponents: [],
 	clientOnlyComponents: [],
 	hydrationDirectives: new Set([]),
-	hoisted: []
+	hoisted: [{
+		type: "inline",
+		value: ``
+	}]
 });
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
 	return $$render`${$$renderScript($$result, "/src/pages/index.astro?astro&type=script&index=0&lang.ts")}${$$renderComponent($$result, "Layout", Layout, {})}`;


### PR DESCRIPTION
## Changes

Astro expects ever script to actually take a spot in the array. The Go compiler would create a sparse array, the Rust compiler just omitted them completely. This PR changes it so instead the Rust compiler includes the empty scripts, which Astro skips naturally.

## Testing

Added tests + tested manually in Astro

## Docs

N/A
