### PR TITLE
perf: reduce allocations

### DIFF
--- a/.changeset/reduce-alloc.md
+++ b/.changeset/reduce-alloc.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler-rs": patch
+---
+
+Improves code generation performance by reducing string and vector allocations.

--- a/crates/astro_codegen/src/css_scoping.rs
+++ b/crates/astro_codegen/src/css_scoping.rs
@@ -218,8 +218,8 @@ fn split_selector_leading_combinator<'i>(
 /// order. A naive `.rev()` would also reverse intra-compound order, placing pseudo-classes
 /// before type selectors (`:not(.x)html` instead of `html:not(.x)`).
 fn flatten_selector_parse_order<'i>(selector: &Selector<'i>) -> Vec<Component<'i>> {
-    let mut flat = Vec::new();
-    for (index, (combinator, compound)) in split_into_compounds(selector).into_iter().enumerate() {
+    let mut flat = Vec::with_capacity(selector.len());
+    for (index, (combinator, compound)) in split_into_compounds(selector).enumerate() {
         if index > 0
             && let Some(combinator) = combinator
         {
@@ -232,25 +232,19 @@ fn flatten_selector_parse_order<'i>(selector: &Selector<'i>) -> Vec<Component<'i
 
 fn split_into_compounds<'i>(
     selector: &Selector<'i>,
-) -> Vec<(Option<Combinator>, Vec<Component<'i>>)> {
+) -> impl Iterator<Item = (Option<Combinator>, Vec<Component<'i>>)> {
     let raw_slice = selector.iter_raw_match_order().as_slice();
     let mut combinators = selector
         .iter_raw_match_order()
         .rev()
         .filter_map(|component| component.as_combinator());
 
-    let compound_slices: Vec<&[Component<'i>]> = raw_slice
-        .split(|component| component.is_combinator())
-        .rev()
-        .collect();
+    let compound_slices = raw_slice.split(|component| component.is_combinator()).rev();
 
-    let mut result = Vec::with_capacity(compound_slices.len());
-    for (index, compound) in compound_slices.iter().enumerate() {
+    compound_slices.enumerate().map(move |(index, compound)| {
         let combinator = if index == 0 { None } else { combinators.next() };
-        result.push((combinator, compound.to_vec()));
-    }
-
-    result
+        (combinator, compound.to_vec())
+    })
 }
 
 /// Stands in for a `*` during printing. Kept implausible as author CSS so the string
@@ -350,7 +344,7 @@ impl ScopeVisitor<'_> {
     /// Scope a single selector, potentially returning multiple selectors.
     fn scope_selector<'i>(&self, selector: &Selector<'i>) -> Vec<Selector<'i>> {
         let compounds = split_into_compounds(selector);
-        let merged = self.merge_pseudo_element_compounds(&compounds);
+        let merged = self.merge_pseudo_element_compounds(compounds);
 
         // Selectors that only reference `&` from inside `:is()`/`:where()`/`:not()`/`:has()`
         // have no top-level nesting to scope against — leaving them untouched avoids
@@ -409,7 +403,7 @@ impl ScopeVisitor<'_> {
     /// to the preceding compound so scoping treats e.g. `.x::part(y)` as one unit.
     fn merge_pseudo_element_compounds<'i>(
         &self,
-        compounds: &[(Option<Combinator>, Vec<Component<'i>>)],
+        compounds: impl Iterator<Item = (Option<Combinator>, Vec<Component<'i>>)>,
     ) -> Vec<(Option<Combinator>, Vec<Component<'i>>)> {
         let mut result: Vec<(Option<Combinator>, Vec<Component<'i>>)> = Vec::new();
 
@@ -419,12 +413,12 @@ impl ScopeVisitor<'_> {
                 Some(Combinator::PseudoElement | Combinator::Part | Combinator::SlotAssignment)
             ) {
                 if let Some(last) = result.last_mut() {
-                    last.1.extend(compound.iter().cloned());
+                    last.1.extend(compound);
                 } else {
-                    result.push((*combinator, compound.clone()));
+                    result.push((combinator, compound));
                 }
             } else {
-                result.push((*combinator, compound.clone()));
+                result.push((combinator, compound));
             }
         }
 

--- a/crates/astro_codegen/src/printer/components.rs
+++ b/crates/astro_codegen/src/printer/components.rs
@@ -11,7 +11,7 @@ use super::expr_to_string;
 use super::runtime;
 use super::whitespace::has_is_raw_attr;
 use crate::options::CompactMode;
-use crate::scanner::{get_jsx_attribute_name, is_custom_element};
+use crate::scanner::{get_jsx_attribute_name, is_custom_element, is_equal_jsx_attribute_name};
 use oxc_ast::ast::*;
 
 /// A client hydration directive parsed from a component's attributes.
@@ -59,7 +59,7 @@ impl<'a> AstroCodegen<'a> {
     pub(super) fn has_server_defer(attrs: &[JSXAttributeItem<'a>]) -> bool {
         attrs.iter().any(|attr| {
             if let JSXAttributeItem::Attribute(attr) = attr {
-                get_jsx_attribute_name(&attr.name) == "server:defer"
+                is_equal_jsx_attribute_name(&attr.name, "server:defer")
             } else {
                 false
             }
@@ -124,17 +124,13 @@ impl<'a> AstroCodegen<'a> {
         // This info is used for client:component-path and client:component-export attributes
         if let Some(info) = &mut hydration_info {
             // Handle member expressions like "components.A" or "defaultImport.Counter1"
-            if name.contains('.') {
-                let parts: Vec<&str> = name.split('.').collect();
-                let namespace = parts[0];
-                let property = parts[1..].join(".");
-
+            if let Some((namespace, property)) = name.split_once('.') {
                 if let Some(import_info) = self.component_imports.get(namespace) {
                     info.component_path = Some(import_info.specifier.clone());
                     // For namespace imports (import * as x), the export is just the property name
                     // For default imports (import x from), the export is "default.Property"
                     if import_info.is_namespace {
-                        info.component_export = Some(property);
+                        info.component_export = Some(property.to_string());
                     } else {
                         // Default or named import - prepend the original export name
                         info.component_export =
@@ -151,15 +147,12 @@ impl<'a> AstroCodegen<'a> {
         // Use resolve_specifier to match the Go compiler's ResolveIdForMatch behaviour —
         // the resolved path must match the key used in serverIslandNameMap.
         if let Some(info) = &mut server_defer_info {
-            if name.contains('.') {
-                let parts: Vec<&str> = name.split('.').collect();
-                let namespace = parts[0];
-                let property = parts[1..].join(".");
+            if let Some((namespace, property)) = name.split_once('.') {
                 if let Some(import_info) = self.component_imports.get(namespace) {
                     info.component_path =
                         Some(self.options.resolve_specifier(&import_info.specifier));
                     info.component_export = if import_info.is_namespace {
-                        Some(property)
+                        Some(property.to_string())
                     } else {
                         Some(format!("{}.{}", import_info.export_name, property))
                     };
@@ -287,9 +280,8 @@ impl<'a> AstroCodegen<'a> {
     ) -> Option<(String, bool, bool, bool, oxc_span::Span)> {
         for attr in attrs {
             if let JSXAttributeItem::Attribute(attr) = attr {
-                let name = get_jsx_attribute_name(&attr.name);
-                let is_html = name == "set:html";
-                let is_text = name == "set:text";
+                let is_html = is_equal_jsx_attribute_name(&attr.name, "set:html");
+                let is_text = is_equal_jsx_attribute_name(&attr.name, "set:text");
                 if is_html || is_text {
                     let (value, needs_unescape, is_raw_text) = match &attr.value {
                         Some(JSXAttributeValue::StringLiteral(lit)) => {
@@ -385,7 +377,7 @@ impl<'a> AstroCodegen<'a> {
 
                     // Skip filtered names
                     if let Some(names) = skip_names
-                        && names.contains(&name.as_str())
+                        && names.contains(&name.as_ref())
                     {
                         continue;
                     }

--- a/crates/astro_codegen/src/printer/elements.rs
+++ b/crates/astro_codegen/src/printer/elements.rs
@@ -12,7 +12,7 @@ use super::whitespace::{has_is_raw_attr, is_raw_element_name};
 use super::{AstroCodegen, expr_to_string};
 use crate::css_scoping;
 use crate::options::{CompactMode, ScopedStyleStrategy};
-use crate::scanner::get_jsx_attribute_name;
+use crate::scanner::{get_jsx_attribute_name, is_equal_jsx_attribute_name};
 use oxc_ast::ast::*;
 
 /// Scope identifier for an element — either a CSS class or a data attribute,
@@ -296,21 +296,20 @@ impl<'a> AstroCodegen<'a> {
     /// Extract the `name` attribute from a slot element, defaulting to `"default"`.
     fn extract_slot_name(attrs: &[JSXAttributeItem<'a>]) -> String {
         for attr in attrs {
-            if let JSXAttributeItem::Attribute(attr) = attr {
-                let attr_name = get_jsx_attribute_name(&attr.name);
-                if attr_name == "name" {
-                    if let Some(JSXAttributeValue::StringLiteral(lit)) = &attr.value {
-                        return lit.value.to_string();
-                    }
-                    if let Some(JSXAttributeValue::ExpressionContainer(expr)) = &attr.value {
-                        // Dynamic slot name
-                        let expr_str = expr
-                            .expression
-                            .as_expression()
-                            .map(expr_to_string)
-                            .unwrap_or_default();
-                        return format!("\" + {expr_str} + \"");
-                    }
+            if let JSXAttributeItem::Attribute(attr) = attr
+                && is_equal_jsx_attribute_name(&attr.name, "name")
+            {
+                if let Some(JSXAttributeValue::StringLiteral(lit)) = &attr.value {
+                    return lit.value.to_string();
+                }
+                if let Some(JSXAttributeValue::ExpressionContainer(expr)) = &attr.value {
+                    // Dynamic slot name
+                    let expr_str = expr
+                        .expression
+                        .as_expression()
+                        .map(expr_to_string)
+                        .unwrap_or_default();
+                    return format!("\" + {expr_str} + \"");
                 }
             }
         }
@@ -320,11 +319,10 @@ impl<'a> AstroCodegen<'a> {
     /// Check if an element has the `is:inline` attribute.
     pub(super) fn has_is_inline_attribute(attrs: &[JSXAttributeItem<'a>]) -> bool {
         for attr in attrs {
-            if let JSXAttributeItem::Attribute(attr) = attr {
-                let name = get_jsx_attribute_name(&attr.name);
-                if name == "is:inline" {
-                    return true;
-                }
+            if let JSXAttributeItem::Attribute(attr) = attr
+                && is_equal_jsx_attribute_name(&attr.name, "is:inline")
+            {
+                return true;
             }
         }
         false
@@ -339,12 +337,13 @@ impl<'a> AstroCodegen<'a> {
     ) -> Option<(&'static str, String, bool, bool, oxc_span::Span)> {
         for attr in attrs {
             if let JSXAttributeItem::Attribute(attr) = attr {
-                let name = get_jsx_attribute_name(&attr.name);
-                if name == "set:html" || name == "set:text" {
-                    let directive_type = if name == "set:html" { "html" } else { "text" };
+                let is_html = is_equal_jsx_attribute_name(&attr.name, "set:html");
+                let is_text = is_equal_jsx_attribute_name(&attr.name, "set:text");
+                if is_html || is_text {
+                    let directive_type = if is_html { "html" } else { "text" };
                     let (value, needs_unescape, is_raw_text) = match &attr.value {
                         Some(JSXAttributeValue::StringLiteral(lit)) => {
-                            if directive_type == "text" {
+                            if is_text {
                                 // set:text with string literal: inline raw text without ${}
                                 (lit.value.as_str().to_string(), false, true)
                             } else {
@@ -364,7 +363,7 @@ impl<'a> AstroCodegen<'a> {
                             }
                             // set:html always needs $$unescapeHTML — its purpose is to inject
                             // raw HTML, and $$render escapes by default.
-                            let needs_unescape = directive_type == "html";
+                            let needs_unescape = is_html;
                             (value_str, needs_unescape, false)
                         }
                         _ => ("void 0".to_string(), false, false),
@@ -493,12 +492,12 @@ impl<'a> AstroCodegen<'a> {
 
         // Pre-scan for class/class:list attributes
         for attr in attrs {
-            if let JSXAttributeItem::Attribute(attr) = attr {
-                let name = get_jsx_attribute_name(&attr.name);
-                if name == "class" || name == "class:list" {
-                    has_class_attr = true;
-                    break;
-                }
+            if let JSXAttributeItem::Attribute(attr) = attr
+                && (is_equal_jsx_attribute_name(&attr.name, "class")
+                    || is_equal_jsx_attribute_name(&attr.name, "class:list"))
+            {
+                has_class_attr = true;
+                break;
             }
         }
 

--- a/crates/astro_codegen/src/printer/escape.rs
+++ b/crates/astro_codegen/src/printer/escape.rs
@@ -10,7 +10,11 @@ use oxc_syntax::xml_entities::XML_ENTITIES;
 /// Escape a string for safe embedding inside a JavaScript template literal.
 ///
 /// Escapes backticks, `${` sequences, and backslashes.
-pub fn escape_template_literal(s: &str) -> String {
+pub fn escape_template_literal(s: &str) -> std::borrow::Cow<'_, str> {
+    if !s.contains(['`', '$', '\\']) {
+        return std::borrow::Cow::Borrowed(s);
+    }
+
     let mut result = String::with_capacity(s.len());
     let mut chars = s.chars().peekable();
 
@@ -25,7 +29,7 @@ pub fn escape_template_literal(s: &str) -> String {
         }
     }
 
-    result
+    std::borrow::Cow::Owned(result)
 }
 
 /// Escape a string for embedding inside a `"..."` JS string literal.

--- a/crates/astro_codegen/src/printer/mod.rs
+++ b/crates/astro_codegen/src/printer/mod.rs
@@ -16,8 +16,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::options::CompactMode;
 use crate::scanner::{
-    AstroScanner, ScanResult, get_jsx_attribute_name, get_jsx_element_name, is_component_name,
-    is_custom_element, should_hoist_script,
+    AstroScanner, ScanResult, get_jsx_element_name, is_component_name, is_custom_element,
+    is_equal_jsx_attribute_name, should_hoist_script,
 };
 use crate::{SourcemapOption, TransformOptions};
 use whitespace::{TextPosition, collapse_html, collapse_jsx};
@@ -768,14 +768,13 @@ impl<'a> AstroCodegen<'a> {
                 .map(|c| format!("\"{}\"", c.name))
                 .collect();
 
-            let regular_components: Vec<String> = self
+            let regular_components = self
                 .scan_result
                 .hydrated_components
                 .iter()
                 .filter(|c| !c.is_custom_element)
                 .rev()
-                .map(|c| c.name.clone())
-                .collect();
+                .map(|c| c.name.clone());
 
             let mut items = custom_elements;
             items.extend(regular_components);
@@ -1436,7 +1435,7 @@ impl<'a> AstroCodegen<'a> {
         if name == "script" {
             let define_vars_expr = el.opening_element.attributes.iter().find_map(|attr| {
                 if let JSXAttributeItem::Attribute(attr) = attr
-                    && get_jsx_attribute_name(&attr.name) == "define:vars"
+                    && is_equal_jsx_attribute_name(&attr.name, "define:vars")
                 {
                     return match &attr.value {
                         Some(JSXAttributeValue::StringLiteral(lit)) => {
@@ -1455,13 +1454,11 @@ impl<'a> AstroCodegen<'a> {
                 self.add_source_mapping_for_span(el.opening_element.span);
 
                 let is_module = el.opening_element.attributes.iter().any(|attr| {
-                    if let JSXAttributeItem::Attribute(attr) = attr {
-                        let attr_name = get_jsx_attribute_name(&attr.name);
-                        if attr_name == "type"
-                            && let Some(JSXAttributeValue::StringLiteral(lit)) = &attr.value
-                        {
-                            return lit.value == "module";
-                        }
+                    if let JSXAttributeItem::Attribute(attr) = attr
+                        && is_equal_jsx_attribute_name(&attr.name, "type")
+                        && let Some(JSXAttributeValue::StringLiteral(lit)) = &attr.value
+                    {
+                        return lit.value == "module";
                     }
                     false
                 });
@@ -1535,7 +1532,7 @@ impl<'a> AstroCodegen<'a> {
                 })
                 || el.opening_element.attributes.iter().any(|attr| {
                     if let JSXAttributeItem::Attribute(attr) = attr {
-                        get_jsx_attribute_name(&attr.name) == "src"
+                        is_equal_jsx_attribute_name(&attr.name, "src")
                     } else {
                         false
                     }

--- a/crates/astro_codegen/src/printer/style.rs
+++ b/crates/astro_codegen/src/printer/style.rs
@@ -7,7 +7,7 @@
 use oxc_ast::ast::*;
 
 use crate::css_scoping;
-use crate::scanner::{get_jsx_attribute_name, get_jsx_element_name};
+use crate::scanner::{get_jsx_attribute_name, get_jsx_element_name, is_equal_jsx_attribute_name};
 
 use super::{AstroCodegen, expr_to_string};
 
@@ -66,7 +66,7 @@ fn extract_styles_from_children<'a>(
                     });
                 } else {
                     let non_hoistable = in_non_hoistable
-                        || matches!(name.as_str(), "svg" | "noscript" | "template");
+                        || matches!(name.as_ref(), "svg" | "noscript" | "template");
                     extract_styles_from_children(&el.children, non_hoistable, blocks);
                 }
             }
@@ -115,11 +115,11 @@ pub(super) fn extract_style_attrs(el: &JSXElement<'_>) -> Vec<(String, String)> 
             match &attr.value {
                 None => {
                     // Boolean/empty attribute (e.g. `is:global`)
-                    attrs.push((name, String::new()));
+                    attrs.push((name.into_owned(), String::new()));
                 }
                 Some(JSXAttributeValue::StringLiteral(lit)) => {
                     // Quoted attribute (e.g. `lang="scss"`)
-                    attrs.push((name, lit.value.as_str().to_string()));
+                    attrs.push((name.into_owned(), lit.value.as_str().to_string()));
                 }
                 _ => {
                     // Expression attributes are skipped
@@ -149,7 +149,7 @@ impl<'a> AstroCodegen<'a> {
                 } else {
                     // Mark descendant context as non-hoistable for svg/noscript/template
                     let non_hoistable = in_non_hoistable
-                        || matches!(name.as_str(), "svg" | "noscript" | "template");
+                        || matches!(name.as_ref(), "svg" | "noscript" | "template");
                     for c in &el.children {
                         self.prescan_styles_child(c, non_hoistable);
                     }
@@ -218,7 +218,7 @@ impl<'a> AstroCodegen<'a> {
         // Check for is:global attribute
         let is_global = el.opening_element.attributes.iter().any(|attr| {
             if let JSXAttributeItem::Attribute(attr) = attr {
-                get_jsx_attribute_name(&attr.name) == "is:global"
+                is_equal_jsx_attribute_name(&attr.name, "is:global")
             } else {
                 false
             }
@@ -269,23 +269,22 @@ impl<'a> AstroCodegen<'a> {
     /// Returns `true` if `define:vars` was found.
     pub(super) fn collect_define_vars(&mut self, el: &JSXElement<'a>) -> bool {
         for attr in &el.opening_element.attributes {
-            if let JSXAttributeItem::Attribute(attr) = attr {
-                let name = get_jsx_attribute_name(&attr.name);
-                if name == "define:vars" {
-                    match &attr.value {
-                        Some(JSXAttributeValue::StringLiteral(lit)) => {
-                            self.define_vars_values
-                                .push(format!("'{}'", lit.value.as_str()));
-                        }
-                        Some(JSXAttributeValue::ExpressionContainer(expr)) => {
-                            if let Some(e) = expr.expression.as_expression() {
-                                self.define_vars_values.push(expr_to_string(e));
-                            }
-                        }
-                        _ => {}
+            if let JSXAttributeItem::Attribute(attr) = attr
+                && is_equal_jsx_attribute_name(&attr.name, "define:vars")
+            {
+                match &attr.value {
+                    Some(JSXAttributeValue::StringLiteral(lit)) => {
+                        self.define_vars_values
+                            .push(format!("'{}'", lit.value.as_str()));
                     }
-                    return true;
+                    Some(JSXAttributeValue::ExpressionContainer(expr)) => {
+                        if let Some(e) = expr.expression.as_expression() {
+                            self.define_vars_values.push(expr_to_string(e));
+                        }
+                    }
+                    _ => {}
                 }
+                return true;
             }
         }
         false

--- a/crates/astro_codegen/src/printer/whitespace.rs
+++ b/crates/astro_codegen/src/printer/whitespace.rs
@@ -31,7 +31,7 @@
 
 use oxc_ast::ast::*;
 
-use crate::scanner::get_jsx_attribute_name;
+use crate::scanner::is_equal_jsx_attribute_name;
 
 /// Returns true for elements whose text content should **never** be touched
 /// by whitespace collapsing.
@@ -56,11 +56,10 @@ pub(super) fn is_raw_element_name(name: &str) -> bool {
 /// Returns true if the element opening tag carries `is:raw`.
 pub(super) fn has_is_raw_attr(attrs: &[JSXAttributeItem<'_>]) -> bool {
     for attr in attrs {
-        if let JSXAttributeItem::Attribute(attr) = attr {
-            let name = get_jsx_attribute_name(&attr.name);
-            if name == "is:raw" {
-                return true;
-            }
+        if let JSXAttributeItem::Attribute(attr) = attr
+            && is_equal_jsx_attribute_name(&attr.name, "is:raw")
+        {
+            return true;
         }
     }
     false

--- a/crates/astro_codegen/src/scanner.rs
+++ b/crates/astro_codegen/src/scanner.rs
@@ -4,6 +4,8 @@
 //! to collect metadata needed by the printer. This separates the analysis
 //! phase from the code generation phase.
 
+use std::borrow::Cow;
+
 use oxc_ast::ast::*;
 use oxc_ast_visit::{Visit, walk};
 use oxc_codegen::Codegen;
@@ -157,7 +159,7 @@ impl<'a> AstroScanner<'a> {
                         .any(|c| c.name == name)
                 {
                     self.server_deferred_components.push(HydratedComponent {
-                        name: name.clone(),
+                        name: name.to_string(),
                         is_custom_element: is_custom,
                     });
                 }
@@ -173,14 +175,14 @@ impl<'a> AstroScanner<'a> {
                                     .insert(namespace.to_string());
                             }
                         } else {
-                            self.client_only_component_names.insert(name.clone());
+                            self.client_only_component_names.insert(name.to_string());
                         }
                         // Store the full component name for metadata resolution
                         if (is_component || is_custom)
                             && !self.client_only_components.iter().any(|c| c.name == name)
                         {
                             self.client_only_components.push(HydratedComponent {
-                                name,
+                                name: name.to_string(),
                                 is_custom_element: is_custom,
                             });
                         }
@@ -195,7 +197,7 @@ impl<'a> AstroScanner<'a> {
                             && !self.hydrated_components.iter().any(|c| c.name == name)
                         {
                             self.hydrated_components.push(HydratedComponent {
-                                name,
+                                name: name.to_string(),
                                 is_custom_element: is_custom,
                             });
                         }
@@ -238,13 +240,11 @@ impl<'a> AstroScanner<'a> {
     fn extract_src_attribute(attrs: &[&JSXAttributeItem<'a>]) -> Option<String> {
         let mut src_value: Option<String> = None;
         for attr in attrs {
-            if let JSXAttributeItem::Attribute(attr) = attr {
-                let attr_name = get_jsx_attribute_name(&attr.name);
-                if attr_name == "src"
-                    && let Some(JSXAttributeValue::StringLiteral(lit)) = &attr.value
-                {
-                    src_value = Some(lit.value.to_string());
-                }
+            if let JSXAttributeItem::Attribute(attr) = attr
+                && is_equal_jsx_attribute_name(&attr.name, "src")
+                && let Some(JSXAttributeValue::StringLiteral(lit)) = &attr.value
+            {
+                src_value = Some(lit.value.to_string());
             }
         }
         src_value
@@ -359,7 +359,7 @@ impl<'a> Visit<'a> for AstroScanner<'a> {
 
         // Track non-hoistable context (template, svg, noscript) so scripts
         // inside these elements are not extracted, matching the Go compiler.
-        let is_non_hoistable = matches!(name.as_str(), "svg" | "noscript" | "template");
+        let is_non_hoistable = matches!(name.as_ref(), "svg" | "noscript" | "template");
         let was_in_non_hoistable = self.in_non_hoistable;
         if is_non_hoistable {
             self.in_non_hoistable = true;
@@ -399,15 +399,15 @@ impl<'a> Visit<'a> for AstroScanner<'a> {
 
 // --- Helper functions (shared with printer) ---
 
-pub fn get_jsx_element_name(name: &JSXElementName<'_>) -> String {
+pub fn get_jsx_element_name<'a>(name: &JSXElementName<'a>) -> Cow<'a, str> {
     match name {
-        JSXElementName::Identifier(ident) => ident.name.to_string(),
-        JSXElementName::IdentifierReference(ident) => ident.name.to_string(),
+        JSXElementName::Identifier(ident) => Cow::Borrowed(ident.name.as_str()),
+        JSXElementName::IdentifierReference(ident) => Cow::Borrowed(ident.name.as_str()),
         JSXElementName::NamespacedName(ns) => {
-            format!("{}:{}", ns.namespace.name, ns.name.name)
+            Cow::Owned(format!("{}:{}", ns.namespace.name, ns.name.name))
         }
-        JSXElementName::MemberExpression(expr) => get_jsx_member_expression_name(expr),
-        JSXElementName::ThisExpression(_) => "this".to_string(),
+        JSXElementName::MemberExpression(expr) => Cow::Owned(get_jsx_member_expression_name(expr)),
+        JSXElementName::ThisExpression(_) => Cow::Borrowed("this"),
     }
 }
 
@@ -420,11 +420,24 @@ fn get_jsx_member_expression_name(expr: &JSXMemberExpression<'_>) -> String {
     format!("{object_name}.{}", expr.property.name)
 }
 
-pub fn get_jsx_attribute_name(name: &JSXAttributeName<'_>) -> String {
+pub fn get_jsx_attribute_name<'a>(name: &JSXAttributeName<'a>) -> Cow<'a, str> {
     match name {
-        JSXAttributeName::Identifier(ident) => ident.name.to_string(),
+        JSXAttributeName::Identifier(ident) => Cow::Borrowed(ident.name.as_str()),
         JSXAttributeName::NamespacedName(ns) => {
-            format!("{}:{}", ns.namespace.name, ns.name.name)
+            Cow::Owned(format!("{}:{}", ns.namespace.name, ns.name.name))
+        }
+    }
+}
+
+pub fn is_equal_jsx_attribute_name(name: &JSXAttributeName<'_>, other: &str) -> bool {
+    match name {
+        JSXAttributeName::Identifier(ident) => ident.name == other,
+        JSXAttributeName::NamespacedName(ns) => {
+            if let Some((namespace, name)) = other.split_once(":") {
+                ns.namespace.name == namespace && ns.name.name == name
+            } else {
+                false
+            }
         }
     }
 }
@@ -439,7 +452,7 @@ pub fn is_custom_element(name: &str) -> bool {
 
 fn opening_element_has_client_only(el: &JSXOpeningElement<'_>) -> bool {
     el.attributes.iter().any(|attr| {
-        matches!(attr, JSXAttributeItem::Attribute(a) if get_jsx_attribute_name(&a.name) == "client:only")
+        matches!(attr, JSXAttributeItem::Attribute(a) if is_equal_jsx_attribute_name(&a.name, "client:only"))
     })
 }
 
@@ -455,7 +468,7 @@ pub fn should_hoist_script(attrs: &oxc_allocator::Vec<'_, JSXAttributeItem<'_>>)
     for attr in attrs {
         if let JSXAttributeItem::Attribute(attr) = attr {
             let attr_name = get_jsx_attribute_name(&attr.name);
-            match attr_name.as_str() {
+            match attr_name.as_ref() {
                 "is:inline" => is_inline = true,
                 "define:vars" => has_define_vars = true,
                 "src" => has_src = true,


### PR DESCRIPTION
## Changes

- Reduced string and vector allocations to improve performance. 5-10% improvement in benchmarks (compared with main).

## Testing

- Run `cargo test`.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
