### PR TITLE
fix(codegen): escape expressions in set:text and transition attributes

### DIFF
--- a/.changeset/escape-set-text-transition-interpolation.md
+++ b/.changeset/escape-set-text-transition-interpolation.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler-rs": patch
+---
+
+Fixes a `${...}` inside a `set:text` or `transition:*` attribute value (e.g. `set:text="${x}"`) being treated as code instead of literal text, which could break the build or run unintended expressions. The value is now emitted verbatim.

--- a/crates/astro_codegen/src/printer/components.rs
+++ b/crates/astro_codegen/src/printer/components.rs
@@ -6,7 +6,7 @@
 
 use super::AstroCodegen;
 use super::elements::ScopeId;
-use super::escape::{decode_html_entities, escape_double_quotes};
+use super::escape::{decode_html_entities, escape_double_quotes, escape_template_literal};
 use super::expr_to_string;
 use super::runtime;
 use super::whitespace::has_is_raw_attr;
@@ -228,8 +228,8 @@ impl<'a> AstroCodegen<'a> {
             self.print(runtime::RENDER);
             self.print("`");
             if is_raw_text {
-                // set:text with string literal - inline raw text without ${}
-                self.print(&value);
+                // Escape template-literal syntax so a literal `${...}` isn't evaluated at render time.
+                self.print(&escape_template_literal(&value));
             } else {
                 self.print("${");
                 if is_html && needs_unescape {
@@ -331,23 +331,22 @@ impl<'a> AstroCodegen<'a> {
         let mut first = true;
 
         // Pre-scan for transition attributes
-        let mut transition_name: Option<(String, oxc_span::Span)> = None;
-        let mut transition_animate: Option<(String, oxc_span::Span)> = None;
-        let mut transition_persist: Option<(String, oxc_span::Span)> = None;
-        let mut transition_persist_props: Option<(String, oxc_span::Span)> = None;
+        let mut transition_name: Option<&JSXAttribute<'a>> = None;
+        let mut transition_animate: Option<&JSXAttribute<'a>> = None;
+        let mut transition_persist: Option<&JSXAttribute<'a>> = None;
+        let mut transition_persist_props: Option<&JSXAttribute<'a>> = None;
 
         for attr in attrs {
             if let JSXAttributeItem::Attribute(attr) = attr {
                 let name = get_jsx_attribute_name(&attr.name);
                 if name == "transition:name" {
-                    transition_name = Some((Self::get_attr_value_string(attr), attr.span));
+                    transition_name = Some(attr);
                 } else if name == "transition:animate" {
-                    transition_animate = Some((Self::get_attr_value_string(attr), attr.span));
+                    transition_animate = Some(attr);
                 } else if name == "transition:persist" {
-                    transition_persist =
-                        Some((Self::get_attr_value_string_or_empty(attr), attr.span));
+                    transition_persist = Some(attr);
                 } else if name == "transition:persist-props" {
-                    transition_persist_props = Some((Self::get_attr_value_string(attr), attr.span));
+                    transition_persist_props = Some(attr);
                 }
             }
         }
@@ -442,34 +441,7 @@ impl<'a> AstroCodegen<'a> {
                         continue;
                     }
 
-                    match &attr.value {
-                        None => {
-                            self.print("true");
-                        }
-                        Some(JSXAttributeValue::StringLiteral(lit)) => {
-                            self.print("\"");
-                            self.print(&escape_double_quotes(lit.value.as_str()));
-                            self.print("\"");
-                        }
-                        Some(JSXAttributeValue::ExpressionContainer(expr)) => {
-                            if let Some(
-                                Expression::TemplateLiteral(_) | Expression::StringLiteral(_),
-                            ) = expr.expression.as_expression()
-                            {
-                                self.print_jsx_expression(&expr.expression);
-                            } else {
-                                self.print("(");
-                                self.print_jsx_expression(&expr.expression);
-                                self.print(")");
-                            }
-                        }
-                        Some(JSXAttributeValue::Element(_el)) => {
-                            self.print("\"[JSX]\"");
-                        }
-                        Some(JSXAttributeValue::Fragment(_)) => {
-                            self.print("\"[Fragment]\"");
-                        }
-                    }
+                    self.print_component_attr_value(attr);
                 }
                 JSXAttributeItem::SpreadAttribute(spread) => {
                     if !first {
@@ -491,11 +463,14 @@ impl<'a> AstroCodegen<'a> {
             }
             first = false;
             // Map to whichever transition attribute comes first
-            self.add_transition_source_mapping(&transition_name, &transition_animate);
-            let name_val = transition_name
-                .as_ref()
-                .map_or_else(|| "\"\"".to_string(), |(v, _)| v.clone());
-            let animate_val = transition_animate.map_or_else(|| "\"\"".to_string(), |(v, _)| v);
+            self.add_transition_source_mapping(
+                transition_name.map(|a| a.span),
+                transition_animate.map(|a| a.span),
+            );
+            let name_val =
+                transition_name.map_or_else(|| "\"\"".to_string(), Self::get_attr_value_string);
+            let animate_val =
+                transition_animate.map_or_else(|| "\"\"".to_string(), Self::get_attr_value_string);
             let hash = self.generate_transition_hash();
             self.print_parts([
                 "\"data-astro-transition-scope\":(",
@@ -513,32 +488,32 @@ impl<'a> AstroCodegen<'a> {
         }
 
         // Print transition:persist-props as a data attribute if present
-        if let Some((props_val, persist_props_span)) = &transition_persist_props {
+        if let Some(props_attr) = transition_persist_props {
             if !first {
                 self.print(",");
             }
             first = false;
-            self.add_source_mapping_for_span(*persist_props_span);
-            self.print_parts(["\"data-astro-transition-persist-props\":", props_val]);
+            self.add_source_mapping_for_span(props_attr.span);
+            let props_val = Self::get_attr_value_string(props_attr);
+            self.print_parts(["\"data-astro-transition-persist-props\":", &props_val]);
         }
 
-        if let Some((ref persist_val, persist_span)) = transition_persist {
+        if let Some(persist_attr) = transition_persist {
             if !first {
                 self.print(",");
             }
             first = false;
-            self.add_source_mapping_for_span(persist_span);
-            // Priority order for the persist ID:
-            // 1. Explicit string value on transition:persist (e.g. transition:persist="form")
-            // 2. transition:name value
-            // 3. Generated hash via $$createTransitionScope
-            let clean_persist = persist_val.trim_matches('"');
-            if !clean_persist.is_empty() {
-                self.print_parts(["\"data-astro-transition-persist\":\"", clean_persist, "\""]);
-            } else if let Some((ref name_val, _)) = transition_name {
-                let clean_val = name_val.trim_matches('"');
-                self.print_parts(["\"data-astro-transition-persist\":\"", clean_val, "\""]);
+            // Persist ID priority: explicit persist value, else transition:name value, else a generated hash.
+            if Self::attr_has_nonempty_value(persist_attr) {
+                self.add_source_mapping_for_span(persist_attr.span);
+                self.print("\"data-astro-transition-persist\":");
+                self.print_component_attr_value(persist_attr);
+            } else if let Some(name_attr) = transition_name {
+                self.add_source_mapping_for_span(persist_attr.span);
+                self.print("\"data-astro-transition-persist\":");
+                self.print_component_attr_value(name_attr);
             } else {
+                self.add_source_mapping_for_span(persist_attr.span);
                 let hash = self.generate_transition_hash();
                 self.print_parts([
                     "\"data-astro-transition-persist\":(",
@@ -621,6 +596,31 @@ impl<'a> AstroCodegen<'a> {
             if let Some(export) = &server_defer.component_export {
                 self.print_parts([",\"server:component-export\":(\"", export, "\")"]);
             }
+        }
+    }
+
+    /// Print an attribute's value as a component prop value (the RHS of a `"key": value` property).
+    fn print_component_attr_value(&mut self, attr: &JSXAttribute<'a>) {
+        match &attr.value {
+            None => self.print("true"),
+            Some(JSXAttributeValue::StringLiteral(lit)) => {
+                self.print("\"");
+                self.print(&escape_double_quotes(lit.value.as_str()));
+                self.print("\"");
+            }
+            Some(JSXAttributeValue::ExpressionContainer(expr)) => {
+                if let Some(Expression::TemplateLiteral(_) | Expression::StringLiteral(_)) =
+                    expr.expression.as_expression()
+                {
+                    self.print_jsx_expression(&expr.expression);
+                } else {
+                    self.print("(");
+                    self.print_jsx_expression(&expr.expression);
+                    self.print(")");
+                }
+            }
+            Some(JSXAttributeValue::Element(_)) => self.print("\"[JSX]\""),
+            Some(JSXAttributeValue::Fragment(_)) => self.print("\"[Fragment]\""),
         }
     }
 }

--- a/crates/astro_codegen/src/printer/components.rs
+++ b/crates/astro_codegen/src/printer/components.rs
@@ -11,7 +11,10 @@ use super::expr_to_string;
 use super::runtime;
 use super::whitespace::has_is_raw_attr;
 use crate::options::CompactMode;
-use crate::scanner::{get_jsx_attribute_name, is_custom_element, is_equal_jsx_attribute_name};
+use crate::scanner::{
+    get_jsx_attribute_name, is_custom_element, is_equal_jsx_attribute_name,
+    jsx_attribute_value_is_empty,
+};
 use oxc_ast::ast::*;
 
 /// A client hydration directive parsed from a component's attributes.
@@ -331,10 +334,10 @@ impl<'a> AstroCodegen<'a> {
         let mut first = true;
 
         // Pre-scan for transition attributes
-        let mut transition_name: Option<&JSXAttribute<'a>> = None;
-        let mut transition_animate: Option<&JSXAttribute<'a>> = None;
-        let mut transition_persist: Option<&JSXAttribute<'a>> = None;
-        let mut transition_persist_props: Option<&JSXAttribute<'a>> = None;
+        let mut transition_name = None;
+        let mut transition_animate = None;
+        let mut transition_persist = None;
+        let mut transition_persist_props = None;
 
         for attr in attrs {
             if let JSXAttributeItem::Attribute(attr) = attr {
@@ -467,10 +470,10 @@ impl<'a> AstroCodegen<'a> {
                 transition_name.map(|a| a.span),
                 transition_animate.map(|a| a.span),
             );
-            let name_val =
-                transition_name.map_or_else(|| "\"\"".to_string(), Self::get_attr_value_string);
-            let animate_val =
-                transition_animate.map_or_else(|| "\"\"".to_string(), Self::get_attr_value_string);
+            let name_val = transition_name
+                .map_or_else(|| "\"\"".to_string(), |a| Self::get_attr_value_string(a));
+            let animate_val = transition_animate
+                .map_or_else(|| "\"\"".to_string(), |a| Self::get_attr_value_string(a));
             let hash = self.generate_transition_hash();
             self.print_parts([
                 "\"data-astro-transition-scope\":(",
@@ -504,7 +507,7 @@ impl<'a> AstroCodegen<'a> {
             }
             first = false;
             // Persist ID priority: explicit persist value, else transition:name value, else a generated hash.
-            if Self::attr_has_nonempty_value(persist_attr) {
+            if !jsx_attribute_value_is_empty(persist_attr) {
                 self.add_source_mapping_for_span(persist_attr.span);
                 self.print("\"data-astro-transition-persist\":");
                 self.print_component_attr_value(persist_attr);

--- a/crates/astro_codegen/src/printer/elements.rs
+++ b/crates/astro_codegen/src/printer/elements.rs
@@ -12,7 +12,9 @@ use super::whitespace::{has_is_raw_attr, is_raw_element_name};
 use super::{AstroCodegen, expr_to_string};
 use crate::css_scoping;
 use crate::options::{CompactMode, ScopedStyleStrategy};
-use crate::scanner::{get_jsx_attribute_name, is_equal_jsx_attribute_name};
+use crate::scanner::{
+    get_jsx_attribute_name, is_equal_jsx_attribute_name, jsx_attribute_value_is_empty,
+};
 use oxc_ast::ast::*;
 
 /// Scope identifier for an element — either a CSS class or a data attribute,
@@ -96,16 +98,6 @@ impl<'a> AstroCodegen<'a> {
     ) {
         if let Some(span) = transition_name.or(transition_animate) {
             self.add_source_mapping_for_span(span);
-        }
-    }
-
-    /// "Explicitly set" for transition:persist: a non-empty string literal or any
-    /// expression value (an empty string counts as unset — Go's `Val != ""`).
-    pub(super) fn attr_has_nonempty_value(attr: &JSXAttribute<'a>) -> bool {
-        match &attr.value {
-            None => false,
-            Some(JSXAttributeValue::StringLiteral(lit)) => !lit.value.as_str().is_empty(),
-            Some(_) => true,
         }
     }
 
@@ -391,9 +383,9 @@ impl<'a> AstroCodegen<'a> {
         let mut static_class: Option<&str> = None;
         let mut class_list_expr: Option<&JSXExpressionContainer<'a>> = None;
 
-        let mut transition_name: Option<&JSXAttribute<'a>> = None;
-        let mut transition_animate: Option<&JSXAttribute<'a>> = None;
-        let mut transition_persist: Option<&JSXAttribute<'a>> = None;
+        let mut transition_name = None;
+        let mut transition_animate = None;
+        let mut transition_persist = None;
 
         for attr in attrs {
             if let JSXAttributeItem::Attribute(attr) = attr {
@@ -420,7 +412,7 @@ impl<'a> AstroCodegen<'a> {
 
         // Persist ID priority: explicit persist value, else transition:name value, else a generated hash.
         if let Some(persist_attr) = transition_persist {
-            if Self::attr_has_nonempty_value(persist_attr) {
+            if !jsx_attribute_value_is_empty(persist_attr) {
                 self.print_html_attribute_with_name(persist_attr, "data-astro-transition-persist");
             } else if let Some(name_attr) = transition_name {
                 self.print_html_attribute_with_name(name_attr, "data-astro-transition-persist");
@@ -446,10 +438,10 @@ impl<'a> AstroCodegen<'a> {
                 transition_name.map(|a| a.span),
                 transition_animate.map(|a| a.span),
             );
-            let name_val =
-                transition_name.map_or_else(|| "\"\"".to_string(), Self::get_attr_value_string);
-            let animate_val =
-                transition_animate.map_or_else(|| "\"\"".to_string(), Self::get_attr_value_string);
+            let name_val = transition_name
+                .map_or_else(|| "\"\"".to_string(), |a| Self::get_attr_value_string(a));
+            let animate_val = transition_animate
+                .map_or_else(|| "\"\"".to_string(), |a| Self::get_attr_value_string(a));
             let hash = self.generate_transition_hash();
             self.print_parts([
                 "${",

--- a/crates/astro_codegen/src/printer/elements.rs
+++ b/crates/astro_codegen/src/printer/elements.rs
@@ -91,13 +91,21 @@ pub(super) fn is_head_element(name: &str) -> bool {
 impl<'a> AstroCodegen<'a> {
     pub(super) fn add_transition_source_mapping(
         &mut self,
-        transition_name: &Option<(String, oxc_span::Span)>,
-        transition_animate: &Option<(String, oxc_span::Span)>,
+        transition_name: Option<oxc_span::Span>,
+        transition_animate: Option<oxc_span::Span>,
     ) {
-        if let Some((_, span)) = transition_name {
-            self.add_source_mapping_for_span(*span);
-        } else if let Some((_, span)) = transition_animate {
-            self.add_source_mapping_for_span(*span);
+        if let Some(span) = transition_name.or(transition_animate) {
+            self.add_source_mapping_for_span(span);
+        }
+    }
+
+    /// "Explicitly set" for transition:persist: a non-empty string literal or any
+    /// expression value (an empty string counts as unset — Go's `Val != ""`).
+    pub(super) fn attr_has_nonempty_value(attr: &JSXAttribute<'a>) -> bool {
+        match &attr.value {
+            None => false,
+            Some(JSXAttributeValue::StringLiteral(lit)) => !lit.value.as_str().is_empty(),
+            Some(_) => true,
         }
     }
 
@@ -187,8 +195,8 @@ impl<'a> AstroCodegen<'a> {
         {
             self.add_source_mapping_for_span(set_span);
             if is_raw_text {
-                // set:text with string literal — inline raw text without ${}
-                self.print(&value);
+                // Escape template-literal syntax so a literal `${...}` isn't evaluated at render time.
+                self.print(&escape_template_literal(&value));
             } else if directive_type == "html" && needs_unescape {
                 // Only use $$unescapeHTML for non-literal expressions
                 self.print_parts(["${", runtime::UNESCAPE_HTML, "(", &value, ")}"]);
@@ -383,9 +391,9 @@ impl<'a> AstroCodegen<'a> {
         let mut static_class: Option<&str> = None;
         let mut class_list_expr: Option<&JSXExpressionContainer<'a>> = None;
 
-        let mut transition_name: Option<(String, oxc_span::Span)> = None;
-        let mut transition_animate: Option<(String, oxc_span::Span)> = None;
-        let mut transition_persist: Option<(String, oxc_span::Span)> = None;
+        let mut transition_name: Option<&JSXAttribute<'a>> = None;
+        let mut transition_animate: Option<&JSXAttribute<'a>> = None;
+        let mut transition_persist: Option<&JSXAttribute<'a>> = None;
 
         for attr in attrs {
             if let JSXAttributeItem::Attribute(attr) = attr {
@@ -399,33 +407,25 @@ impl<'a> AstroCodegen<'a> {
                         class_list_expr = Some(expr);
                     }
                 } else if name == "transition:name" {
-                    transition_name = Some((Self::get_attr_value_string(attr), attr.span));
+                    transition_name = Some(attr);
                 } else if name == "transition:animate" {
-                    transition_animate = Some((Self::get_attr_value_string(attr), attr.span));
+                    transition_animate = Some(attr);
                 } else if name == "transition:persist" {
-                    transition_persist =
-                        Some((Self::get_attr_value_string_or_empty(attr), attr.span));
+                    transition_persist = Some(attr);
                 }
             }
         }
 
         let has_merged_class = static_class.is_some() && class_list_expr.is_some();
 
-        // Handle transition:persist — priority order for the persist ID:
-        // 1. If transition:persist has an explicit string value (e.g. transition:persist="form"),
-        //    use that value directly.
-        // 2. If transition:name is present, use its value.
-        // 3. Otherwise generate a unique hash via $$createTransitionScope.
-        if let Some((ref persist_val, persist_span)) = transition_persist {
-            self.add_source_mapping_for_span(persist_span);
-            let clean_persist = persist_val.trim_matches('"');
-            if !clean_persist.is_empty() {
-                // Explicit string value on transition:persist — use it directly.
-                self.print_parts([" data-astro-transition-persist=\"", clean_persist, "\""]);
-            } else if let Some((ref name_val, _)) = transition_name {
-                let clean_val = name_val.trim_matches('"');
-                self.print_parts([" data-astro-transition-persist=\"", clean_val, "\""]);
+        // Persist ID priority: explicit persist value, else transition:name value, else a generated hash.
+        if let Some(persist_attr) = transition_persist {
+            if Self::attr_has_nonempty_value(persist_attr) {
+                self.print_html_attribute_with_name(persist_attr, "data-astro-transition-persist");
+            } else if let Some(name_attr) = transition_name {
+                self.print_html_attribute_with_name(name_attr, "data-astro-transition-persist");
             } else {
+                self.add_source_mapping_for_span(persist_attr.span);
                 let hash = self.generate_transition_hash();
                 self.print_parts([
                     "${",
@@ -442,9 +442,14 @@ impl<'a> AstroCodegen<'a> {
         }
 
         if transition_name.is_some() || transition_animate.is_some() {
-            self.add_transition_source_mapping(&transition_name, &transition_animate);
-            let name_val = transition_name.map_or_else(|| "\"\"".to_string(), |(v, _)| v);
-            let animate_val = transition_animate.map_or_else(|| "\"\"".to_string(), |(v, _)| v);
+            self.add_transition_source_mapping(
+                transition_name.map(|a| a.span),
+                transition_animate.map(|a| a.span),
+            );
+            let name_val =
+                transition_name.map_or_else(|| "\"\"".to_string(), Self::get_attr_value_string);
+            let animate_val =
+                transition_animate.map_or_else(|| "\"\"".to_string(), Self::get_attr_value_string);
             let hash = self.generate_transition_hash();
             self.print_parts([
                 "${",
@@ -637,14 +642,6 @@ impl<'a> AstroCodegen<'a> {
                 }
             }
             _ => "\"\"".to_string(),
-        }
-    }
-
-    /// Get attribute value as a string, or empty string if no value (for boolean attrs).
-    pub(super) fn get_attr_value_string_or_empty(attr: &JSXAttribute<'a>) -> String {
-        match &attr.value {
-            None => String::new(),
-            _ => Self::get_attr_value_string(attr),
         }
     }
 

--- a/crates/astro_codegen/src/printer/printer_tests.rs
+++ b/crates/astro_codegen/src/printer/printer_tests.rs
@@ -3357,3 +3357,63 @@ fn test_jsx_object_literal_lookup() {
         parsed.errors
     );
 }
+
+#[test]
+fn test_no_template_literal_injection_via_set_and_transition() {
+    // Literal `${...}` values are escaped so they render as inert text inside the
+    // `$$render` template literal.
+    let literal_escaped = [
+        r#"<div transition:persist="${globalThis.x=1}"></div>"#,
+        r#"<div transition:persist transition:name="${globalThis.x=1}"></div>"#,
+        r#"<div set:text="${globalThis.x=1}"></div>"#,
+    ];
+    for src in literal_escaped {
+        let output = compile_astro(src);
+        assert!(
+            output.contains("\\${globalThis.x=1}"),
+            "literal ${{...}} must be escaped for `{src}`:\n{output}"
+        );
+        assert!(
+            !output.contains("=\"${globalThis.x=1}") && !output.contains(">${globalThis.x=1}"),
+            "unescaped ${{...}} leaked into template literal for `{src}`:\n{output}"
+        );
+    }
+
+    // Expression values route through $$addAttribute, so the `${...}` sits inside a JS
+    // double-quoted string argument where it is inert — never a live substitution.
+    let expr_inert = [
+        r#"<div transition:persist={"${globalThis.x=1}"}></div>"#,
+        r#"<div transition:persist transition:name={"${globalThis.x=1}"}></div>"#,
+    ];
+    for src in expr_inert {
+        let output = compile_astro(src);
+        assert!(
+            output.contains(
+                r#"$$addAttribute("${globalThis.x=1}", "data-astro-transition-persist")"#
+            ),
+            "expression ${{...}} must be passed as an inert string to $$addAttribute for `{src}`:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn test_no_template_literal_injection_via_component_set_text() {
+    let source = "---\nimport Button from './Button.astro';\n---\n<Button set:text=\"${globalThis.x=1}\"></Button>";
+    let output = compile_astro(source);
+    assert!(
+        output.contains("$$render`\\${globalThis.x=1}`"),
+        "component set:text must escape ${{...}}:\n{output}"
+    );
+}
+
+#[test]
+fn test_component_transition_persist_expression_uses_add_attribute_value() {
+    // Expression transition:persist on a component must emit the expression as a prop
+    // value, not a mangled quoted string.
+    let source = "---\nimport M from './M.astro';\n---\n<M transition:persist={pid} />";
+    let output = compile_astro(source);
+    assert!(
+        output.contains(r#""data-astro-transition-persist": pid"#),
+        "component transition:persist expression must be emitted verbatim: {output}"
+    );
+}

--- a/crates/astro_codegen/src/scanner.rs
+++ b/crates/astro_codegen/src/scanner.rs
@@ -418,6 +418,16 @@ pub fn get_jsx_attribute_name<'a>(name: &JSXAttributeName<'a>) -> Cow<'a, str> {
     }
 }
 
+/// Whether the attribute has no usable value: a boolean attribute or an empty
+/// string literal, both treated as unset. An expression value is never empty.
+pub fn jsx_attribute_value_is_empty(attr: &JSXAttribute<'_>) -> bool {
+    match &attr.value {
+        None => true,
+        Some(JSXAttributeValue::StringLiteral(lit)) => lit.value.as_str().is_empty(),
+        Some(_) => false,
+    }
+}
+
 pub fn is_equal_jsx_attribute_name(name: &JSXAttributeName<'_>, other: &str) -> bool {
     match name {
         JSXAttributeName::Identifier(ident) => ident.name == other,


### PR DESCRIPTION
## Changes

What the title says, we didn't properly escape `${}` inside those attributes, as such it was possible to generate bad JS due to the wrapping backtick attribute of `$render`

## Testing

Added tests

## Docs

N/A
