### PR TITLE
chore: doctype lowercase

### DIFF
--- a/crates/astro_codegen/src/printer/printer_tests.rs
+++ b/crates/astro_codegen/src/printer/printer_tests.rs
@@ -65,7 +65,7 @@ import Component from 'test';
 
 #[test]
 fn test_doctype() {
-    let source = "<!DOCTYPE html><div></div>";
+    let source = "<!doctype html><div></div>";
     let output = compile_astro(source);
 
     assert!(output.contains("<div></div>"), "Missing div element");

--- a/crates/astro_codegen/tests/fixtures/doctype.astro
+++ b/crates/astro_codegen/tests/fixtures/doctype.astro
@@ -1,1 +1,1 @@
-<!DOCTYPE html><div/>
+<!doctype html><div/>

--- a/docs/SYNTAX_SPEC.md
+++ b/docs/SYNTAX_SPEC.md
@@ -144,7 +144,7 @@ The `is:raw` attribute on any element allows the content to be treated as raw te
 The [HTML doctype declaration](https://html.spec.whatwg.org/multipage/syntax.html#the-doctype) is allowed.
 
 ```astro
-<!DOCTYPE html>
+<!doctype html>
 ```
 
 ##### Top-level text nodes


### PR DESCRIPTION
## Changes

- Update `doctype` examples and test fixtures to use the lowercase HTML5 doctype (`<!doctype html>`).
- Align documentation, fixtures, and tests with the formatter's expected output and modern HTML conventions.
- No functional behavior changes; this is a consistency cleanup.

## Testing

- Updated the existing doctype printer test (`crates/astro_codegen/src/printer/printer_tests.rs`) to use the lowercase doctype.
- Updated the `crates/astro_codegen/tests/fixtures/doctype.astro` fixture accordingly.
- No additional tests were required because this change only updates the expected input/output casing and does not modify parsing or code generation behavior.

## Docs

- Updated `docs/SYNTAX_SPEC.md` to use the lowercase HTML5 `doctype`.
- This keeps the documentation consistent with the formatter output and common HTML5 style.

## Resources

- [html.spec.whatwg.org : the-doctype](https://html.spec.whatwg.org/multipage/syntax.html#the-doctype)
- [endtimes.dev : why-lowercase-letters-save-data](https://endtimes.dev/why-lowercase-letters-save-data/)
- [kangax/html-minifer #822 : use-lowercase-doctype](https://github.com/kangax/html-minifier/issues/822)
- [twbs/bootstrap #24217 : switch to lowercase doctype](https://github.com/twbs/bootstrap/pull/24217)
- [prettier/prettier #6502 : print <!doctype html> lowercase rather than uppercase](https://github.com/prettier/prettier/issues/6502)
- [MDN Glossary : Doctype](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)
