### PR TITLE
fix(css): `:global()` scoping for attribute/class suffixes and selector lists

### DIFF
--- a/.changeset/global-attr-class-suffix-and-list.md
+++ b/.changeset/global-attr-class-suffix-and-list.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/compiler-binding": patch
+"@astrojs/compiler-rs": patch
+---
+
+Fixes two `:global()` scoping mismatches with the Go compiler. An attribute or class suffixed onto a leading `:global()` (`:global(a)[role="button"]`, `:global(a).cls`) is no longer mis-scoped and now stays global. A selector list inside `:global()` (`.x :global(ul, ol)`) no longer drops later items; the scope prefix is distributed across every item instead.

--- a/crates/astro_codegen/src/css_scoping.rs
+++ b/crates/astro_codegen/src/css_scoping.rs
@@ -1974,4 +1974,48 @@ mod tests {
             ".panel:where(.astro-xxxxxx) > .a, .panel:where(.astro-xxxxxx) .b {\n}\n"
         );
     }
+
+    #[test]
+    fn test_global_selector_list_comma_in_attribute_value() {
+        // The top-level comma split must ignore commas inside an attribute value, so a
+        // leading-combinator list with a comma in `[data-x="a,b"]` stays a single item.
+        assert_eq!(
+            scope(".panel :global(> [data-x=\"a,b\"], > .c){}"),
+            ".panel:where(.astro-xxxxxx) > [data-x=\"a,b\"], .panel:where(.astro-xxxxxx) > .c {\n}\n"
+        );
+        assert_eq!(
+            scope_attribute(".panel :global(> [data-x=\"a,b\"], > .c){}"),
+            ".panel[data-astro-cid-xxxxxx] > [data-x=\"a,b\"], .panel[data-astro-cid-xxxxxx] > .c {\n}\n"
+        );
+    }
+
+    #[test]
+    fn test_global_selector_list_comma_in_nested_pseudo() {
+        // The top-level comma split must ignore commas inside `:is(...)` parentheses, so a
+        // leading-combinator list keeps `> :is(a, b)` as a single item.
+        assert_eq!(
+            scope(".panel :global(> :is(a, b), > .c){}"),
+            ".panel:where(.astro-xxxxxx) > :is(a, b), .panel:where(.astro-xxxxxx) > .c {\n}\n"
+        );
+    }
+
+    #[test]
+    fn test_global_selector_list_with_leading_local() {
+        // A leading local part scopes the compound AND the `:global()` list distributes,
+        // so each item carries the scoped leading local.
+        assert_eq!(
+            scope(".a:global(.x, .y){}"),
+            ".a:where(.astro-xxxxxx).x, .a:where(.astro-xxxxxx).y {\n}\n"
+        );
+        assert_eq!(
+            scope_attribute(".a:global(.x, .y){}"),
+            ".a[data-astro-cid-xxxxxx].x, .a[data-astro-cid-xxxxxx].y {\n}\n"
+        );
+    }
+
+    #[test]
+    fn test_global_selector_list_trailing_comma() {
+        // An empty item from a trailing comma is dropped, leaving just the real item.
+        assert_eq!(scope(":global(ul,){}"), "ul {\n}\n");
+    }
 }

--- a/crates/astro_codegen/src/css_scoping.rs
+++ b/crates/astro_codegen/src/css_scoping.rs
@@ -43,21 +43,84 @@ impl<'i> Visitor<'i> for GlobalSelectorVisitor {
     }
 
     fn visit_selector_list(&mut self, selectors: &mut SelectorList<'i>) -> Result<(), Self::Error> {
-        Visit::visit_children(selectors, self)
-    }
-
-    fn visit_selector(&mut self, selector: &mut Selector<'i>) -> Result<(), Self::Error> {
-        // Both passes below flatten and rebuild the whole selector, so skip them unless
-        // there is actually a `:global()` to handle — most selectors have none.
-        if !selector_contains_global(selector) {
-            return Ok(());
+        // Rebuild the rule's top-level selector list, expanding any `:global()` that wraps a
+        // selector list into one selector per item (`.x :global(ul, ol)` becomes the two
+        // selectors `.x :global(ul)` and `.x :global(ol)`). We deliberately do NOT descend
+        // into `:not()`/`:is()`/`:has()` arguments: like the Go compiler, a nested
+        // `:global(...)` stays opaque and is emitted verbatim.
+        let mut expanded: Vec<Selector<'i>> = Vec::with_capacity(selectors.0.len());
+        for selector in selectors.0.iter() {
+            // Both passes below flatten and rebuild the whole selector, so skip them unless
+            // there is actually a `:global()` to handle — most selectors have none.
+            if !selector_contains_global(selector) {
+                expanded.push(selector.clone());
+                continue;
+            }
+            for mut normalized in expand_global_selector_lists(selector) {
+                hoist_global_leading_combinators(&mut normalized);
+                expanded.push(normalized);
+            }
         }
-        // Don't descend into `:not()`/`:is()`/`:has()` arguments: like the Go compiler, a
-        // nested `:global(...)` stays opaque and is emitted verbatim.
-        normalize_global_pseudos(selector);
-        hoist_global_leading_combinators(selector);
+        selectors.0 = expanded.into();
         Ok(())
     }
+}
+
+/// Normalize `:global()` components in a single selector and distribute any that wrap a
+/// selector list, returning one selector per combination of list items.
+///
+/// A selector normally yields a single result; only a `:global()` whose argument is a
+/// comma-separated list (`:global(ul, ol)`) produces more than one, and multiple such
+/// globals in the same selector expand as a cartesian product (`:global(a, b) :global(c, d)`
+/// → `a c`, `a d`, `b c`, `b d`), matching the split-`:global()` workaround.
+fn expand_global_selector_lists<'i>(selector: &Selector<'i>) -> Vec<Selector<'i>> {
+    let flat = flatten_selector_parse_order(selector);
+    let per_component: Vec<Vec<Component<'i>>> =
+        flat.into_iter().map(normalize_component_options).collect();
+
+    let mut combos: Vec<Vec<Component<'i>>> = vec![Vec::new()];
+    for options in per_component {
+        let mut next = Vec::with_capacity(combos.len() * options.len());
+        for prefix in &combos {
+            for option in &options {
+                let mut combo = prefix.clone();
+                combo.push(option.clone());
+                next.push(combo);
+            }
+        }
+        combos = next;
+    }
+
+    combos.into_iter().map(Selector::from).collect()
+}
+
+/// Expand a single component into its normalized options.
+///
+/// Every component maps to exactly one option except a `:global()` list, which maps to one
+/// `Global` per list item (`:global(ul, ol)` → `[Global(ul), Global(ol)]`).
+fn normalize_component_options<'i>(component: Component<'i>) -> Vec<Component<'i>> {
+    let Component::NonTSPseudoClass(PseudoClass::CustomFunction { name, arguments }) = &component
+    else {
+        return vec![component];
+    };
+    if !name.eq_ignore_ascii_case("global") {
+        return vec![component];
+    }
+
+    if let Some(items) = parse_global_argument_list(arguments) {
+        return items
+            .into_iter()
+            .map(|selector| {
+                Component::NonTSPseudoClass(PseudoClass::Global {
+                    selector: Box::new(selector),
+                })
+            })
+            .collect();
+    }
+
+    // Empty or unparseable argument; leave it to the single-selector path, which keeps an
+    // empty `:global()` opaque.
+    vec![normalize_component(component)]
 }
 
 /// Cheap, allocation-free check for a top-level `:global()` — the raw `CustomFunction`
@@ -126,6 +189,116 @@ fn parse_global_argument<'i>(tokens: &TokenList<'_>) -> Selector<'i> {
         Ok(selector) => selector.into_owned(),
         Err(_) => empty_selector(),
     }
+}
+
+/// Parse a `:global(...)` argument as a selector list, so a list can be distributed across
+/// the enclosing selector. Returns `None` when the argument is empty or every item fails to
+/// parse.
+fn parse_global_argument_list<'i>(tokens: &TokenList<'_>) -> Option<Vec<Selector<'i>>> {
+    let serialized = token_list_to_css(tokens);
+    let argument_text = serialized.trim();
+    if argument_text.is_empty() {
+        return None;
+    }
+    let options = parser_options();
+
+    // Common case: a comma-separated list with no leading combinators parses directly, and
+    // lightningcss handles every tokenization edge case (commas inside attribute values,
+    // `:is(a, b)`, and so on).
+    if let Ok(list) = SelectorList::parse_string_with_options(argument_text, options)
+        && !list.0.is_empty()
+    {
+        return Some(
+            list.0
+                .into_iter()
+                .map(|selector| {
+                    // Detach from the temporary serialized string, then normalize any nested
+                    // `:global()` inside the item.
+                    let mut selector = selector.into_owned();
+                    normalize_global_pseudos(&mut selector);
+                    selector
+                })
+                .collect(),
+        );
+    }
+
+    // A leading combinator (`:global(> *)`, `:global(> .a, > .b)`) can't be parsed as a list
+    // by lightningcss, so split top-level commas ourselves and parse each item with its own
+    // leading combinator hoisted in.
+    let items: Vec<Selector<'i>> = split_top_level_commas(argument_text)
+        .into_iter()
+        .filter_map(parse_global_argument_item)
+        .collect();
+    if items.is_empty() { None } else { Some(items) }
+}
+
+/// Parse one item of a `:global(...)` argument, hoisting a leading combinator (`> .a`) into
+/// the selector. Returns `None` if the item is empty or fails to parse.
+fn parse_global_argument_item<'i>(item_text: &str) -> Option<Selector<'i>> {
+    let item_text = item_text.trim();
+    if item_text.is_empty() {
+        return None;
+    }
+    let options = parser_options();
+
+    let mut selector = if let Some((combinator, rest)) = split_leading_combinator_str(item_text) {
+        let rest = rest.trim();
+        if rest.is_empty() {
+            return None;
+        }
+        let parsed = Selector::parse_string_with_options(rest, options).ok()?;
+        let mut flat = vec![Component::Combinator(combinator)];
+        flat.extend(flatten_selector_parse_order(&parsed));
+        Selector::from(flat).into_owned()
+    } else {
+        Selector::parse_string_with_options(item_text, options)
+            .ok()?
+            .into_owned()
+    };
+
+    normalize_global_pseudos(&mut selector);
+    Some(selector)
+}
+
+/// Split a `:global(...)` argument into its top-level comma-separated items, ignoring commas
+/// nested inside `()`/`[]` or string literals.
+fn split_top_level_commas(input: &str) -> Vec<&str> {
+    let mut items = Vec::new();
+    let mut start = 0;
+    let mut paren = 0i32;
+    let mut bracket = 0i32;
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+
+    for (index, ch) in input.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if let Some(open_quote) = quote {
+            match ch {
+                '\\' => escaped = true,
+                _ if ch == open_quote => quote = None,
+                _ => {}
+            }
+            continue;
+        }
+        match ch {
+            '\\' => escaped = true,
+            '"' | '\'' => quote = Some(ch),
+            '(' => paren += 1,
+            ')' => paren -= 1,
+            '[' => bracket += 1,
+            ']' => bracket -= 1,
+            ',' if paren == 0 && bracket == 0 => {
+                items.push(&input[start..index]);
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+    items.push(&input[start..]);
+    items
 }
 
 fn split_leading_combinator_str(input: &str) -> Option<(Combinator, &str)> {
@@ -508,15 +681,23 @@ impl ScopeVisitor<'_> {
     }
 
     /// Process a compound that contains :global() — strip the wrapper and return
-    /// inner content unscoped, while scoping non-global parts.
+    /// inner content unscoped, while scoping a leading local part.
+    ///
+    /// Only a local (non-global) simple selector that appears *before* the first `:global()`
+    /// makes the compound scoped (`.local:global(.g)` → `.local[scope].g`). Once a `:global()`
+    /// has been seen, any following type/class/id/attribute selector belongs to the global
+    /// compound and stays unscoped (`:global(a)[role="button"]` → `a[role="button"]`,
+    /// `:global(a).cls` → `a.cls`), matching the Go compiler.
     fn process_global_compound<'i>(&self, compound: &[Component<'i>]) -> Vec<Component<'i>> {
         let mut result = Vec::new();
-        let mut has_non_global = false;
+        let mut has_leading_local = false;
+        let mut seen_global = false;
         let mut index = 0;
 
         while index < compound.len() {
             let component = &compound[index];
             if let Component::NonTSPseudoClass(PseudoClass::Global { selector }) = component {
+                seen_global = true;
                 let trailing_end = compound[index + 1..]
                     .iter()
                     .take_while(|component| {
@@ -539,7 +720,11 @@ impl ScopeVisitor<'_> {
                 continue;
             }
 
-            has_non_global = true;
+            // A leading local part (before any `:global()`) is what gets scoped. A local part
+            // after a `:global()` is a suffix on the global compound and stays unscoped.
+            if !seen_global {
+                has_leading_local = true;
+            }
             result.push(component.clone());
             index += 1;
         }
@@ -549,9 +734,8 @@ impl ScopeVisitor<'_> {
             return result;
         }
 
-        // If there were non-global parts mixed in (e.g., `.class:global(.bar)`),
-        // we need to scope the non-global parts.
-        if has_non_global {
+        // Scope only when there was a leading local part (e.g., `.class:global(.bar)`).
+        if has_leading_local {
             return self.inject_scope_into_compound(&result);
         }
 
@@ -1560,13 +1744,12 @@ mod tests {
 
     #[test]
     fn test_global_does_not_overglobalize_local_parts() {
-        assert_eq!(
-            scope(":global(.foo).is-active{}"),
-            ".foo:where(.astro-xxxxxx).is-active {\n}\n"
-        );
+        // A class suffixed onto a leading `:global()` attaches to the global compound and
+        // stays unscoped (Go parity); only a local part BEFORE the `:global()` gets scoped.
+        assert_eq!(scope(":global(.foo).is-active{}"), ".foo.is-active {\n}\n");
         assert_eq!(
             scope_attribute(":global(.foo).is-active{}"),
-            ".foo[data-astro-cid-xxxxxx].is-active {\n}\n"
+            ".foo.is-active {\n}\n"
         );
         assert_eq!(
             scope(":global(.foo):hover .child{}"),
@@ -1635,9 +1818,160 @@ mod tests {
         // The inner `:global()` survives the outer expansion and is stripped by the printer;
         // the trailing local part still gets scoped, like the non-nested `:global(.x).foo`.
         assert_eq!(scope(":global(:global(.x)){}"), ".x {\n}\n");
+        // `.foo` follows the (nested) `:global()`, so like `:global(.foo).is-active` it
+        // attaches to the global compound and stays unscoped.
+        assert_eq!(scope(":global(:global(.x)).foo{}"), ".x.foo {\n}\n");
+    }
+
+    // An attribute or class suffixed onto a leading `:global()` must NOT be scoped — the
+    // whole compound stays global, matching the Go compiler.
+
+    #[test]
+    fn test_global_attribute_suffix_stays_global() {
         assert_eq!(
-            scope(":global(:global(.x)).foo{}"),
-            ".x.foo:where(.astro-xxxxxx) {\n}\n"
+            scope(":global(a)[role=\"button\"]{}"),
+            "a[role=\"button\"] {\n}\n"
+        );
+        assert_eq!(
+            scope_attribute(":global(a)[role=\"button\"]{}"),
+            "a[role=\"button\"] {\n}\n"
+        );
+    }
+
+    #[test]
+    fn test_global_attribute_suffix_with_scoped_ancestor() {
+        assert_eq!(
+            scope("section > :global(a)[role=\"button\"]{}"),
+            "section:where(.astro-xxxxxx) > a[role=\"button\"] {\n}\n"
+        );
+        assert_eq!(
+            scope_attribute("section > :global(a)[role=\"button\"]{}"),
+            "section[data-astro-cid-xxxxxx] > a[role=\"button\"] {\n}\n"
+        );
+    }
+
+    #[test]
+    fn test_global_class_suffix_stays_global() {
+        assert_eq!(scope(":global(a).cls{}"), "a.cls {\n}\n");
+        assert_eq!(scope_attribute(":global(a).cls{}"), "a.cls {\n}\n");
+    }
+
+    #[test]
+    fn test_global_id_suffix_stays_global() {
+        assert_eq!(scope(":global(a)#id{}"), "a#id {\n}\n");
+    }
+
+    #[test]
+    fn test_global_multiple_suffixes_stay_global() {
+        assert_eq!(scope(":global(a).b.c{}"), "a.b.c {\n}\n");
+    }
+
+    #[test]
+    fn test_leading_local_before_global_with_suffix_scopes() {
+        // A local part BEFORE the `:global()` still scopes, and the trailing suffix
+        // rides along on the already-scoped compound (Go: `.local[scope].global.bar`).
+        assert_eq!(
+            scope(".local:global(.global).bar{}"),
+            ".local:where(.astro-xxxxxx).global.bar {\n}\n"
+        );
+        assert_eq!(
+            scope_attribute(".local:global(.global)[data-x]{}"),
+            ".local[data-astro-cid-xxxxxx].global[data-x] {\n}\n"
+        );
+    }
+
+    // A selector list inside `:global()` must keep every item, with the scope prefix
+    // distributed across each. (Go drops the prefix on later items, leaking them globally.)
+
+    #[test]
+    fn test_global_selector_list_bare() {
+        assert_eq!(scope(":global(ul, ol){}"), "ul, ol {\n}\n");
+    }
+
+    #[test]
+    fn test_global_selector_list_with_scoped_ancestor() {
+        assert_eq!(
+            scope(".x :global(ul, ol){}"),
+            ".x:where(.astro-xxxxxx) ul, .x:where(.astro-xxxxxx) ol {\n}\n"
+        );
+        assert_eq!(
+            scope_attribute(".x :global(ul, ol){}"),
+            ".x[data-astro-cid-xxxxxx] ul, .x[data-astro-cid-xxxxxx] ol {\n}\n"
+        );
+    }
+
+    #[test]
+    fn test_global_selector_list_with_scoped_descendant() {
+        assert_eq!(
+            scope(".x :global(ul, ol) .y{}"),
+            ".x:where(.astro-xxxxxx) ul .y:where(.astro-xxxxxx), .x:where(.astro-xxxxxx) ol .y:where(.astro-xxxxxx) {\n}\n"
+        );
+    }
+
+    #[test]
+    fn test_global_selector_list_with_suffix() {
+        // Each distributed item carries the trailing suffix, still unscoped.
+        assert_eq!(scope(":global(ul, ol).cls{}"), "ul.cls, ol.cls {\n}\n");
+        assert_eq!(
+            scope(":global(div, span):hover{}"),
+            "div:hover, span:hover {\n}\n"
+        );
+    }
+
+    #[test]
+    fn test_global_selector_list_within_larger_list() {
+        assert_eq!(
+            scope(".a :global(ul, ol), .b :global(p){}"),
+            ".a:where(.astro-xxxxxx) ul, .a:where(.astro-xxxxxx) ol, .b:where(.astro-xxxxxx) p {\n}\n"
+        );
+    }
+
+    #[test]
+    fn test_global_selector_list_cartesian() {
+        // Two list globals in one selector expand as a cartesian product.
+        assert_eq!(
+            scope(":global(a, b) :global(c, d){}"),
+            "a c, a d, b c, b d {\n}\n"
+        );
+    }
+
+    #[test]
+    fn test_global_selector_list_is_workaround_unchanged() {
+        // The `:is()` workaround keeps working (single item, no distribution).
+        assert_eq!(
+            scope(".x :global(:is(ul, ol)){}"),
+            ".x:where(.astro-xxxxxx) :is(ul, ol) {\n}\n"
+        );
+    }
+
+    #[test]
+    fn test_global_selector_list_with_leading_child_combinators() {
+        // Each item keeps its own hoisted combinator and the scope prefix is distributed.
+        assert_eq!(
+            scope(".panel :global(> .a, > .b){}"),
+            ".panel:where(.astro-xxxxxx) > .a, .panel:where(.astro-xxxxxx) > .b {\n}\n"
+        );
+        assert_eq!(
+            scope_attribute(".panel :global(> .a, > .b){}"),
+            ".panel[data-astro-cid-xxxxxx] > .a, .panel[data-astro-cid-xxxxxx] > .b {\n}\n"
+        );
+    }
+
+    #[test]
+    fn test_global_selector_list_with_leading_sibling_combinators() {
+        assert_eq!(
+            scope(".panel :global(+ .a, ~ .b){}"),
+            ".panel:where(.astro-xxxxxx) + .a, .panel:where(.astro-xxxxxx) ~ .b {\n}\n"
+        );
+    }
+
+    #[test]
+    fn test_global_selector_list_mixed_leading_combinator() {
+        // A combinator on only some items still distributes; items without one stay
+        // descendants of the scoped ancestor.
+        assert_eq!(
+            scope(".panel :global(> .a, .b){}"),
+            ".panel:where(.astro-xxxxxx) > .a, .panel:where(.astro-xxxxxx) .b {\n}\n"
         );
     }
 }

--- a/crates/astro_codegen/src/css_scoping.rs
+++ b/crates/astro_codegen/src/css_scoping.rs
@@ -45,9 +45,9 @@ impl<'i> Visitor<'i> for GlobalSelectorVisitor {
     fn visit_selector_list(&mut self, selectors: &mut SelectorList<'i>) -> Result<(), Self::Error> {
         // Rebuild the rule's top-level selector list, expanding any `:global()` that wraps a
         // selector list into one selector per item (`.x :global(ul, ol)` becomes the two
-        // selectors `.x :global(ul)` and `.x :global(ol)`). We deliberately do NOT descend
-        // into `:not()`/`:is()`/`:has()` arguments: like the Go compiler, a nested
-        // `:global(...)` stays opaque and is emitted verbatim.
+        // selectors `.x :global(ul)` and `.x :global(ol)`). Arguments of `:not()`/`:is()`/
+        // `:has()` are not traversed, so a nested `:global(...)` stays opaque and is emitted
+        // verbatim.
         let mut expanded: Vec<Selector<'i>> = Vec::with_capacity(selectors.0.len());
         for selector in selectors.0.iter() {
             // Both passes below flatten and rebuild the whole selector, so skip them unless
@@ -72,7 +72,7 @@ impl<'i> Visitor<'i> for GlobalSelectorVisitor {
 /// A selector normally yields a single result; only a `:global()` whose argument is a
 /// comma-separated list (`:global(ul, ol)`) produces more than one, and multiple such
 /// globals in the same selector expand as a cartesian product (`:global(a, b) :global(c, d)`
-/// → `a c`, `a d`, `b c`, `b d`), matching the split-`:global()` workaround.
+/// → `a c`, `a d`, `b c`, `b d`).
 fn expand_global_selector_lists<'i>(selector: &Selector<'i>) -> Vec<Selector<'i>> {
     let flat = flatten_selector_parse_order(selector);
     let per_component: Vec<Vec<Component<'i>>> =
@@ -202,9 +202,8 @@ fn parse_global_argument_list<'i>(tokens: &TokenList<'_>) -> Option<Vec<Selector
     }
     let options = parser_options();
 
-    // Common case: a comma-separated list with no leading combinators parses directly, and
-    // lightningcss handles every tokenization edge case (commas inside attribute values,
-    // `:is(a, b)`, and so on).
+    // Common case: a comma-separated list with no leading combinators parses directly.
+    // lightningcss handles commas nested inside attribute values or `:is(a, b)`.
     if let Ok(list) = SelectorList::parse_string_with_options(argument_text, options)
         && !list.0.is_empty()
     {
@@ -223,8 +222,8 @@ fn parse_global_argument_list<'i>(tokens: &TokenList<'_>) -> Option<Vec<Selector
     }
 
     // A leading combinator (`:global(> *)`, `:global(> .a, > .b)`) can't be parsed as a list
-    // by lightningcss, so split top-level commas ourselves and parse each item with its own
-    // leading combinator hoisted in.
+    // by lightningcss, so split the top-level commas manually and parse each item with its
+    // own leading combinator hoisted in.
     let items: Vec<Selector<'i>> = split_top_level_commas(argument_text)
         .into_iter()
         .filter_map(parse_global_argument_item)
@@ -687,7 +686,7 @@ impl ScopeVisitor<'_> {
     /// makes the compound scoped (`.local:global(.g)` → `.local[scope].g`). Once a `:global()`
     /// has been seen, any following type/class/id/attribute selector belongs to the global
     /// compound and stays unscoped (`:global(a)[role="button"]` → `a[role="button"]`,
-    /// `:global(a).cls` → `a.cls`), matching the Go compiler.
+    /// `:global(a).cls` → `a.cls`).
     fn process_global_compound<'i>(&self, compound: &[Component<'i>]) -> Vec<Component<'i>> {
         let mut result = Vec::new();
         let mut has_leading_local = false;
@@ -1745,7 +1744,7 @@ mod tests {
     #[test]
     fn test_global_does_not_overglobalize_local_parts() {
         // A class suffixed onto a leading `:global()` attaches to the global compound and
-        // stays unscoped (Go parity); only a local part BEFORE the `:global()` gets scoped.
+        // stays unscoped; only a local part BEFORE the `:global()` gets scoped.
         assert_eq!(scope(":global(.foo).is-active{}"), ".foo.is-active {\n}\n");
         assert_eq!(
             scope_attribute(":global(.foo).is-active{}"),
@@ -1824,7 +1823,7 @@ mod tests {
     }
 
     // An attribute or class suffixed onto a leading `:global()` must NOT be scoped — the
-    // whole compound stays global, matching the Go compiler.
+    // whole compound stays global.
 
     #[test]
     fn test_global_attribute_suffix_stays_global() {
@@ -1869,7 +1868,7 @@ mod tests {
     #[test]
     fn test_leading_local_before_global_with_suffix_scopes() {
         // A local part BEFORE the `:global()` still scopes, and the trailing suffix
-        // rides along on the already-scoped compound (Go: `.local[scope].global.bar`).
+        // rides along on the already-scoped compound.
         assert_eq!(
             scope(".local:global(.global).bar{}"),
             ".local:where(.astro-xxxxxx).global.bar {\n}\n"
@@ -1881,7 +1880,7 @@ mod tests {
     }
 
     // A selector list inside `:global()` must keep every item, with the scope prefix
-    // distributed across each. (Go drops the prefix on later items, leaking them globally.)
+    // distributed across each.
 
     #[test]
     fn test_global_selector_list_bare() {
@@ -1937,7 +1936,8 @@ mod tests {
 
     #[test]
     fn test_global_selector_list_is_workaround_unchanged() {
-        // The `:is()` workaround keeps working (single item, no distribution).
+        // `:global(:is(ul, ol))` is a single component, not a selector list, so it is
+        // emitted intact with no distribution.
         assert_eq!(
             scope(".x :global(:is(ul, ol)){}"),
             ".x:where(.astro-xxxxxx) :is(ul, ol) {\n}\n"

--- a/crates/astro_codegen/tests/css_scoping_snapshots.rs
+++ b/crates/astro_codegen/tests/css_scoping_snapshots.rs
@@ -1,0 +1,93 @@
+//! Snapshot tests for `:global()` CSS scoping.
+//!
+//! The glob-based `snapshots.rs` harness only captures the generated JS
+//! (`TransformResult::code`), where a top-level `<style>` is replaced by a
+//! virtual-module import. The *scoped CSS* itself lives on
+//! `TransformResult::css`, so these tests run the full compiler on a small set
+//! of representative `:global()` shapes and snapshot the extracted CSS.
+//!
+//! These are deliberately focused spot-checks of the end-to-end pipeline; the
+//! exhaustive per-branch coverage lives in the `css_scoping` unit tests.
+
+use astro_codegen::{ScopedStyleStrategy, TransformOptions, transform};
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+/// Compile an `.astro` source and return the extracted, scoped CSS.
+fn scoped_css(source: &str, strategy: ScopedStyleStrategy) -> String {
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, source, SourceType::astro()).parse_astro();
+    assert!(ret.errors.is_empty(), "parse errors: {:?}", ret.errors);
+
+    let options = TransformOptions::new()
+        .with_internal_url("http://localhost:3000/")
+        .with_astro_global_args("\"https://astro.build\"")
+        .with_scoped_style_strategy(strategy);
+
+    transform(&allocator, source, options, &ret.root)
+        .css
+        .join("\n")
+}
+
+/// Snapshot the scoped CSS with stable, prefix-free snapshot names co-located in
+/// `tests/snapshots/`.
+macro_rules! assert_css_snapshot {
+    ($name:expr, $css:expr) => {
+        insta::with_settings!({ prepend_module_to_snapshot => false }, {
+            insta::assert_snapshot!($name, $css);
+        });
+    };
+}
+
+/// A `:global()` selector list under a scoped ancestor distributes the scope
+/// prefix across every list item.
+#[test]
+fn global_selector_list_scoped_ancestor() {
+    let css = scoped_css(
+        "<div class=\"wrapper\"><ul></ul></div><style>.wrapper :global(ul, ol) { margin: 0; }</style>",
+        ScopedStyleStrategy::Where,
+    );
+    assert_css_snapshot!("global_selector_list_scoped_ancestor", css);
+}
+
+/// A class/attribute suffixed onto a leading `:global()` stays global (unscoped).
+#[test]
+fn global_suffix_stays_global() {
+    let css = scoped_css(
+        "<a class=\"cls\"></a><style>:global(a).cls { color: red; } :global(a)[role=\"button\"] { color: blue; }</style>",
+        ScopedStyleStrategy::Where,
+    );
+    assert_css_snapshot!("global_suffix_stays_global", css);
+}
+
+/// A `:global()` list whose items carry leading combinators keeps each item's
+/// combinator and distributes the scope prefix.
+#[test]
+fn global_leading_combinator_list() {
+    let css = scoped_css(
+        "<div class=\"panel\"></div><style>.panel :global(> .a, > .b) { color: green; }</style>",
+        ScopedStyleStrategy::Where,
+    );
+    assert_css_snapshot!("global_leading_combinator_list", css);
+}
+
+/// Two list `:global()` in one selector expand as a cartesian product.
+#[test]
+fn global_selector_list_cartesian() {
+    let css = scoped_css(
+        "<style>:global(a, b) :global(c, d) { color: red; }</style>",
+        ScopedStyleStrategy::Where,
+    );
+    assert_css_snapshot!("global_selector_list_cartesian", css);
+}
+
+/// The same list distribution under the attribute scoping strategy.
+#[test]
+fn global_selector_list_attribute_strategy() {
+    let css = scoped_css(
+        "<div class=\"wrapper\"><ul></ul></div><style>.wrapper :global(ul, ol) { margin: 0; }</style>",
+        ScopedStyleStrategy::Attribute,
+    );
+    assert_css_snapshot!("global_selector_list_attribute_strategy", css);
+}

--- a/crates/astro_codegen/tests/snapshots/global_leading_combinator_list.snap
+++ b/crates/astro_codegen/tests/snapshots/global_leading_combinator_list.snap
@@ -1,0 +1,7 @@
+---
+source: crates/astro_codegen/tests/css_scoping_snapshots.rs
+expression: css
+---
+.panel:where(.astro-463vp4hy) > .a, .panel:where(.astro-463vp4hy) > .b {
+  color: green;
+}

--- a/crates/astro_codegen/tests/snapshots/global_selector_list_attribute_strategy.snap
+++ b/crates/astro_codegen/tests/snapshots/global_selector_list_attribute_strategy.snap
@@ -1,0 +1,7 @@
+---
+source: crates/astro_codegen/tests/css_scoping_snapshots.rs
+expression: css
+---
+.wrapper[data-astro-cid-icmhjx3i] ul, .wrapper[data-astro-cid-icmhjx3i] ol {
+  margin: 0;
+}

--- a/crates/astro_codegen/tests/snapshots/global_selector_list_cartesian.snap
+++ b/crates/astro_codegen/tests/snapshots/global_selector_list_cartesian.snap
@@ -1,0 +1,7 @@
+---
+source: crates/astro_codegen/tests/css_scoping_snapshots.rs
+expression: css
+---
+a c, a d, b c, b d {
+  color: red;
+}

--- a/crates/astro_codegen/tests/snapshots/global_selector_list_scoped_ancestor.snap
+++ b/crates/astro_codegen/tests/snapshots/global_selector_list_scoped_ancestor.snap
@@ -1,0 +1,7 @@
+---
+source: crates/astro_codegen/tests/css_scoping_snapshots.rs
+expression: css
+---
+.wrapper:where(.astro-icmhjx3i) ul, .wrapper:where(.astro-icmhjx3i) ol {
+  margin: 0;
+}

--- a/crates/astro_codegen/tests/snapshots/global_suffix_stays_global.snap
+++ b/crates/astro_codegen/tests/snapshots/global_suffix_stays_global.snap
@@ -1,0 +1,11 @@
+---
+source: crates/astro_codegen/tests/css_scoping_snapshots.rs
+expression: css
+---
+a.cls {
+  color: red;
+}
+
+a[role="button"] {
+  color: #00f;
+}


### PR DESCRIPTION
## Changes

Closes #90. Fixes two `:global()` scoping mismatches with the Go compiler (`@astrojs/compiler` 2.13.1). Both compile successfully today, so the breakage is silent — the mis-scoped rule just never matches.

**Bug 1 — attribute & class suffixes.** An attribute or class suffixed onto a leading `:global()` was mis-scoped, injecting the scope selector into the global compound:

| Source | Before | After (matches Go) |
| --- | --- | --- |
| `:global(a)[role="button"]` | `a[data-astro-cid-X][role="button"]` | `a[role="button"]` |
| `section > :global(a)[role="button"]` | `section[cid]>a[data-astro-cid-X][role="button"]` | `section[cid] > a[role="button"]` |
| `:global(a).cls` | `a[data-astro-cid-X].cls` | `a.cls` |

The rule is now positional: only a local part **before** the first `:global()` scopes the compound (`.local:global(.g)` → `.local[cid].g`, unchanged). Anything after `:global()` is a suffix on the global compound and stays unscoped. (Pseudo-class/element suffixes were already correct.)

**Bug 2 — selector lists.** A selector list inside `:global()` dropped every item after the first (`.x :global(ul, ol)` → `.x[cid] ul`, silently losing `ol`). The list is now parsed in full and **distributed** across the enclosing selector so every item gets the scope prefix:

| Source | Before | After |
| --- | --- | --- |
| `:global(ul, ol)` | `ul` | `ul, ol` |
| `.x :global(ul, ol)` | `.x[cid] ul` | `.x[cid] ul, .x[cid] ol` |
| `:global(a, b) :global(c, d)` | `a c` | `a c, a d, b c, b d` (cartesian) |
| `.panel :global(> .a, > .b)` | `.panel[cid] > .a` | `.panel[cid] > .a, .panel[cid] > .b` |

This intentionally differs from Go here: Go keeps later list items but drops their prefix (`.x[cid] ul,ol`), leaking `ol` globally. Distributing the prefix keeps every item scoped, matching the existing workarounds (`.x :global(ul), .x :global(ol)` and `.x :global(:is(ul, ol))`), which still work unchanged.

## Testing

Added unit tests covering: attribute/class/id suffixes staying global, suffixes with a scoped ancestor, leading-local-before-global still scoping, bare/nested selector lists, distribution with suffixes and within a larger selector list, the cartesian case, and leading child/sibling/mixed combinators inside a list.

### Existing tests changed

Two existing assertions encoded the old buggy behavior and now match the Go compiler (verified directly against 2.13.1):

- `test_global_does_not_overglobalize_local_parts`: `:global(.foo).is-active` now compiles to `.foo.is-active` (was `.foo:where(.astro-xxxxxx).is-active`). Its `:global(.foo):hover .child` assertions are unchanged.
- `test_nested_global_strips_both_wrappers`: `:global(:global(.x)).foo` now compiles to `.x.foo` (was `.x.foo:where(.astro-xxxxxx)`).

## Docs

Bug fix only — no public documentation changes. A changeset is included (patch for `@astrojs/compiler-rs` and `@astrojs/compiler-binding`).
