### PR TITLE
fix(codegen): preserve remaining attributes on `define:vars` scripts

### DIFF
--- a/.changeset/define-vars-preserve-attrs.md
+++ b/.changeset/define-vars-preserve-attrs.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/compiler-binding": patch
+"@astrojs/compiler-rs": patch
+---
+
+Fixes an issue where a `<script define:vars={...}>` element lost all of its other attributes (such as `data-astro-rerun`, `id`, or `nonce`) in the compiled output.

--- a/crates/astro_codegen/src/printer/mod.rs
+++ b/crates/astro_codegen/src/printer/mod.rs
@@ -1491,19 +1491,25 @@ impl<'a> AstroCodegen<'a> {
                         .collect()
                 };
 
+                // Print the opening tag with the element's remaining attributes
+                // (`type="module"`, `data-astro-rerun`, `id`, `nonce`, …) —
+                // print_html_attributes skips the compiler directives
+                // (define:vars, is:inline, …) itself.
+                self.print("<script");
+                self.print_html_attributes(&el.opening_element.attributes, None, false);
+                self.print(">");
+
                 if is_module {
                     // type="module" — no IIFE, just prepend $$defineScriptVars
-                    self.print("<script type=\"module\">");
+                    // (imports are illegal inside functions)
                     self.print("${");
                     self.print(runtime::DEFINE_SCRIPT_VARS);
                     self.print("(");
                     self.print(&define_vars_expr);
                     self.print(")}");
                     self.print(&escape_template_literal(&text_content));
-                    self.print("</script>");
                 } else {
                     // No type="module" — wrap in IIFE
-                    self.print("<script>");
                     self.print("(function(){${");
                     self.print(runtime::DEFINE_SCRIPT_VARS);
                     self.print("(");
@@ -1511,8 +1517,8 @@ impl<'a> AstroCodegen<'a> {
                     self.print(")}");
                     self.print(&escape_template_literal(&text_content));
                     self.print("})();");
-                    self.print("</script>");
                 }
+                self.print("</script>");
                 return;
             }
         }

--- a/crates/astro_codegen/tests/fixtures/define_vars_script_preserves_attributes.astro
+++ b/crates/astro_codegen/tests/fixtures/define_vars_script_preserves_attributes.astro
@@ -1,0 +1,9 @@
+---
+const foo = "bar";
+---
+<script is:inline data-astro-rerun define:vars={{ foo }}>
+  console.log(foo);
+</script>
+<script type="module" id="probe" nonce="abc" define:vars={{ foo }}>
+  console.log(foo);
+</script>

--- a/crates/astro_codegen/tests/fixtures/define_vars_script_preserves_attributes.snap
+++ b/crates/astro_codegen/tests/fixtures/define_vars_script_preserves_attributes.snap
@@ -1,0 +1,22 @@
+---
+source: crates/astro_codegen/tests/snapshots.rs
+input_file: crates/astro_codegen/tests/fixtures/define_vars_script_preserves_attributes.astro
+---
+import { render as $$render, createComponent as $$createComponent, defineScriptVars as $$defineScriptVars, createMetadata as $$createMetadata } from "http://localhost:3000/";
+export const $$metadata = $$createMetadata(import.meta.url, {
+	modules: [],
+	hydratedComponents: [],
+	clientOnlyComponents: [],
+	hydrationDirectives: new Set([]),
+	hoisted: []
+});
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+	const foo = "bar";
+	return $$render`<script data-astro-rerun>(function(){${$$defineScriptVars({ foo })}
+  console.log(foo);
+})();<\/script>
+<script type="module" id="probe" nonce="abc">${$$defineScriptVars({ foo })}
+  console.log(foo);
+<\/script>`;
+}, undefined, undefined);
+export default $$Component;


### PR DESCRIPTION
## Changes

Fixes #94.

- `<script define:vars={...}>` elements previously compiled to a hardcoded opening tag (`<script>` or `<script type="module">`), discarding every other attribute — `data-astro-rerun`, `id`, `nonce`, any `data-*`. The v5 compiler preserved them.
- The `define:vars` branch in the printer now emits the opening tag through `print_html_attributes`, the same path regular elements use, which already skips the compiler directives (`define:vars`, `is:inline`, …). `type="module"` is printed as a normal attribute, so the module/IIFE split only affects the script body now.
- Practical impact of the bug: `data-astro-rerun` + `define:vars` scripts silently stop re-executing after ClientRouter navigations (that's how we hit it — a giscus embed and a page toggle died after the first SPA navigation, with no build error).

## Testing

- New fixture `define_vars_script_preserves_attributes.astro` covering both the IIFE branch (`is:inline data-astro-rerun define:vars`) and the module branch (`type="module" id nonce define:vars`).
- All existing snapshots pass unchanged — for scripts whose only attributes are the directives themselves, the emitted tag is byte-identical to before.
- `cargo test -p astro_codegen`: 458 unit tests + snapshot suite green.

## Docs

Bug fix only — restores the documented v5 behavior (attributes on `define:vars` scripts were never documented as dropped).
