### PR TITLE
feat: add agents docs and skill comments

### DIFF
--- a/.agents/skills/writing-comments/SKILL.md
+++ b/.agents/skills/writing-comments/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: writing-comments
+description: How to write inline (//), rustdoc item (///), and module (//!) comments in the compiler-rs codebase, plus JSDoc in the TypeScript wrapper — for contributors reading the source, not end users. Use whenever writing or editing comments in Rust or TypeScript source, including comments added incidentally while fixing a bug or building a feature.
+---
+
+# Writing Comments
+
+## Purpose
+
+Comments and doc comments in this repository are read by contributors, months
+or years after they were written, with none of the context you have right now.
+This skill defines who that reader is, what each kind of comment is for, and
+which patterns are banned. It applies to both the Rust crates (`crates/`) and
+the TypeScript wrapper (`packages/compiler/`).
+
+## Scope Boundary
+
+This skill governs **contributor-facing** comments in the source a contributor
+reads at HEAD. It does **not** apply to end-user documentation:
+
+- The NAPI type definitions at
+  [`crates/astro_napi/index.d.ts`](../../../crates/astro_napi/index.d.ts) are
+  **generated** by `napi build`. Never hand-edit them or their comments; change
+  the `#[napi]` Rust source and rebuild instead.
+- Doc comments on the public `@astrojs/compiler-rs` API in
+  [`packages/compiler`](../../../packages/compiler) are surfaced to npm users
+  through editor IntelliSense. Write those for compiler **users** calling
+  `transform`, not for contributors reading the source.
+
+Everything below is about the source a contributor reads at HEAD.
+
+## The Reader
+
+Write for a compiler-rs contributor who is competent in Rust (and TypeScript for
+the wrapper) but has **no access to your current context**: not this
+conversation, not the pull request, not the issue, not the diff. They see only
+the repository at HEAD.
+
+Two consequences follow directly:
+
+1. **Never narrate change history.** Words like "now", "previously", "no
+   longer", "the new approach" are meaningless at HEAD, where only one approach
+   exists. State how the code works, not how it came to be.
+2. **Never address the reviewer.** A comment that argues your change is correct
+   ("this properly handles X") belongs in the PR description, not in the source.
+   The comment must justify the code as it stands, permanently.
+
+## Three Kinds of Comments, Three Different Jobs
+
+| Kind                 | Syntax                             | Job         | Contains                                                                                       |
+| -------------------- | ---------------------------------- | ----------- | ---------------------------------------------------------------------------------------------- |
+| Module docs          | `//!` at the top of a file/module  | Explanation | Why the module exists, the concepts and terms it defines, how the pieces relate, design rationale |
+| Item docs            | `///` directly above a declaration | Reference   | The contract: behavior, inputs/outputs, invariants, panics, errors. Neutral and factual        |
+| Inline comments      | `//` inside a body                 | Rationale   | Only what the code cannot say: constraints, workarounds (with issue links), non-obvious coupling |
+
+In the TypeScript wrapper the mapping is the same, with `/** */` playing the
+role of `///`/`//!` and `//` for rationale.
+
+Do not mix the jobs. Implementation details do not belong in the `///` contract
+— put them as `//` comments inside the body. The contract does not belong
+scattered across inline comments — put it on the declaration.
+
+The `//!` docs at the top of
+[`crates/astro_codegen/src/lib.rs`](../../../crates/astro_codegen/src/lib.rs)
+show the target register: they state what the crate produces and give the shape
+of the generated output, in the present tense, without defending a change. The
+`AwaitDetector` in
+[`crates/astro_codegen/src/printer/mod.rs`](../../../crates/astro_codegen/src/printer/mod.rs)
+shows inline rationale doing its job — it explains why scanning the whole
+subtree is sound ("can over-mark but never under-mark") rather than restating
+what the visitor does.
+
+## The Deletion Test
+
+Before writing any comment, ask: **does this state something the reader cannot
+recover from the code itself?**
+
+- If the information is already carried by names, types, or structure, do not
+  write the comment. If the name fails to carry it, improve the name.
+- Information that legitimately needs a comment: an invariant, a rationale, a
+  coupling to code elsewhere, a workaround with a link, surprising behavior of a
+  dependency, a term of art the module defines.
+
+When editing later, the same test applies in reverse: a comment that no longer
+passes it should be deleted, not left to rot.
+
+## Link to the Issue for Workarounds
+
+Any comment that explains a workaround, a `HACK`, a regression guard, or
+surprising behavior of a dependency **must link the GitHub issue or PR** that
+motivates it. The link is what lets a future reader tell whether the workaround
+is still needed. Much of the parser and codegen here is constrained by Astro's
+[oxc fork](https://github.com/withastro/oxc); when its behavior forces your
+hand, cite the source.
+
+```rust
+// oxc parses the fragment shorthand as a JSX namespace; unwrap it back to a
+// fragment so downstream printing matches Astro's runtime. See
+// https://github.com/withastro/compiler-rs/issues/123
+```
+
+A workaround with no link is indistinguishable from a mistake.
+
+## Banned Patterns
+
+**Narrating the next line.** Delete these on sight:
+
+```rust
+// Increment the generation counter
+generation += 1;
+```
+
+**Change-history narration.** Rewrite as present-tense rationale:
+
+```rust
+// BAD: We now intern the scope hash instead of recomputing it.
+// GOOD: The scope hash is interned because every element lookup reads it.
+```
+
+**Reviewer-addressed justification.** Move the argument to the PR:
+
+```rust
+// BAD: This correctly handles the self-closing component from the bug report.
+// GOOD: Components self-close in the AST but must emit an explicit closing tag,
+//       so the runtime can inject slotted children.
+```
+
+**Restated rustdoc.** A `///` doc that rewords the item name says nothing:
+
+```rust
+// BAD:
+/// Scans the styles.
+fn scan_styles(...)
+
+// GOOD:
+/// Collects every `<style>` block in the template into `ScanResult`, recording
+/// whether each is scoped so the printer can hash the scope id once.
+fn scan_styles(...)
+```
+
+**Vague hedging.** "Some cases", "various reasons", "handles edge cases",
+"etc." — either name them or drop the sentence.
+
+**Emojis.** Banned everywhere in this repository, comments included.
+
+**Ad-hoc section banners** (`// ----- helpers -----`, `// ==== TYPES ====`).
+Use the region markers below instead.
+
+## Region Comments
+
+Long files and large `impl`/`trait` blocks group related items with paired
+region markers, which editors fold on:
+
+```rust
+// #region printing components
+...
+// #endregion
+```
+
+This is the convention for navigation in this codebase. Rules:
+
+- Every `// #region` has a matching `// #endregion`. An unpaired marker breaks
+  editor folding silently.
+- The name states what the group contains. It can be a plain label
+  (`shared helpers`) or anchored to a function
+  (`#region collapse_html`) when the region holds one entry point and its
+  private support code.
+- Use regions only where they earn their keep: files or `impl`/`trait` blocks
+  long enough that folding helps navigation. A file that fits on two screens
+  does not need them.
+- A region name is organization, not documentation. It never substitutes for
+  rustdoc on the items inside it.
+
+## Conventions in This Codebase
+
+**Rustdoc sections.** State the contract with the standard headings when they
+apply: `# Errors` for what a `Result`-returning function returns on failure,
+`# Panics` for the conditions that trigger a panic, `# Safety` for the
+invariants an `unsafe fn` requires, and `# Examples` with a fenced ` ```rust `
+block for non-obvious usage. A doctest in `# Examples` is compiled and run by
+`cargo test`, so keep it building.
+
+**Intra-doc links.** Reference other items with bracketed paths
+(`` [`AstroCodegen`] ``, `` [`ScanResult`] ``) rather than a bare name, so a
+rename breaks the build instead of rotting silently and editors can jump to the
+target.
+
+**TODO.** Use `// TODO:` for deferred work and link an issue when one tracks it.
+There is no `FIXME` idiom in this codebase — do not introduce one.
+
+**TypeScript wrapper.** In `packages/compiler`, `@param name - description`,
+`@returns`, and `@throws` state the contract; `{@link Symbol}` cross-references;
+`@deprecated` states the migration and the removal horizon. Remember the scope
+boundary: JSDoc on the exported API is end-user documentation.
+
+## Editing Existing Code
+
+- Preserve existing comments. If your change alters behavior, extend or correct
+  the specific prose — never replace it with generic text. Deleting hard-won
+  context is worse than leaving a comment slightly stale.
+- When your change makes a comment false, fix it in the same diff. A stale
+  comment is worse than none.
+- Match the surrounding density. A heavily documented module deserves the same
+  level on new items; do not blanket a sparse module with comments.
+
+## Self-Check Before Finishing
+
+After completing any task that touched comments, re-read **only the comments in
+your diff**, in isolation from the code changes:
+
+1. Does each one pass the deletion test?
+2. Does any reference the conversation, the change itself, or the reviewer?
+3. Does every workaround link its issue or PR?
+4. Would a reader without access to the diff understand each one?
+
+Fix or delete what fails. Deletion is the default; a missing comment is cheaper
+than a misleading one.
+
+## References
+
+- [Diátaxis](https://diataxis.fr/) — the framework behind the explanation /
+  reference / rationale split above.
+- [The rustdoc book](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html)
+  — conventions for `///` and `//!` documentation.
+- [TSDoc](https://tsdoc.org/) — the tag reference for the TypeScript wrapper.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,155 @@
+# Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+# Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+# Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+# Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+# Style Guide
+
+- This is a mixed Rust + TypeScript repo. Follow the conventions and patterns you detect in the surrounding code.
+- **Rust** is formatted by `cargo fmt` (rustfmt) and linted by `cargo clippy`. Indentation is 4 spaces; the edition is `2024`. CI runs `cargo fmt -- --check` and `cargo clippy -- -D warnings`, so clippy warnings fail the build.
+- **JavaScript/TypeScript** is formatted and linted by [Biome](./biome.jsonc): tabs at width 2, line width 100, single quotes, semicolons, trailing commas. `.astro` files are excluded from Biome formatting.
+- Run `pnpm format` to auto-format the whole repo (`biome format --write` + `cargo fmt` + import sorting).
+- Run `pnpm lint` to lint the whole repo (`biome lint` + `cargo clippy`). `pnpm lint:fix` applies safe fixes.
+- The Rust toolchain is pinned in [`rust-toolchain.toml`](./rust-toolchain.toml); do not override the channel.
+
+# Writing Comments
+
+These rules apply to **every** comment you write, including ones added incidentally while fixing a bug. Full guidance with examples: [`.agents/skills/writing-comments/SKILL.md`](./.agents/skills/writing-comments/SKILL.md).
+
+- Write for a contributor reading the code at HEAD, months later, with no access to this conversation, the PR, or the diff.
+- Never narrate change history ("now", "previously", "no longer") and never address the reviewer ("this correctly handles..."). State how the code works, not how it came to be or why the change is right.
+- Deletion test: a comment must state something the reader cannot recover from the code. If names or types already carry it, don't write it.
+- `///` item docs and `//!` module docs state the contract (behavior, inputs/outputs, invariants, panics, errors); `//` comments carry rationale only. Anchor a workaround to the GitHub issue or PR that motivates it.
+- Group long files or `impl`/`trait` blocks with paired `// #region` / `// #endregion` markers instead of ad-hoc `// ---- section ----` banners.
+- When your change alters documented behavior, extend or correct the existing prose — never replace specific docs with generic text.
+- No emojis anywhere in source, comments included.
+- Exception: the generated NAPI type definitions at `crates/astro_napi/index.d.ts` are generated — don't hand-edit them. Doc comments on the public `@astrojs/compiler-rs` API in `packages/compiler` are surfaced to npm users through IntelliSense; write those for compiler **users**, not contributors.
+
+# Environment Guide
+
+- Use `node -e` for scripting tasks, not `python` or `python3`.
+- After changing Rust source, rebuild the native addon with `pnpm run build:napi` before the TypeScript tests can exercise it — the `.node` binary does not hot-reload.
+
+# Monorepo Structure
+
+This directory is a Git monorepo containing both Rust crates and a `pnpm` workspace. It is the Astro compiler rewritten in Rust.
+
+- **Rust crates** live in `crates/`:
+  - `crates/astro_codegen/` — the core engine that transforms an Astro AST into JavaScript.
+  - `crates/astro_napi/` — Node.js [NAPI](https://napi.rs/) bindings that expose the compiler to JavaScript. Building it emits an `astro.*.node` (or `astro.*.wasm`) native addon.
+- **npm packages** live in `packages/`:
+  - `packages/compiler/` — the `@astrojs/compiler-rs` package, a TypeScript wrapper around the NAPI bindings.
+- The `pnpm` workspace spans `packages/*` and `crates/astro_napi` (see [`pnpm-workspace.yaml`](./pnpm-workspace.yaml)).
+- The parser and code generator come from Astro's [oxc fork](https://github.com/withastro/oxc) (`oxc_*` crates), pinned to a single git revision in [`Cargo.toml`](./Cargo.toml). Several of those crates carry Astro-specific changes; keep every `oxc_*` dependency on the same revision to avoid duplicate-crate errors.
+
+Edits to Rust source take effect in the JS API only after rebuilding the NAPI addon (`pnpm run build:napi`).
+
+# Building
+
+```shell
+# Build the NAPI native addon (debug mode)
+pnpm run build:napi
+
+# Build the TypeScript package
+pnpm run build:compiler
+
+# Build everything
+pnpm run build:all
+```
+
+# Running Tests
+
+## Rust tests
+
+```shell
+# Run all Rust tests (unit + snapshot)
+cargo test
+
+# Run only astro_codegen tests
+cargo test -p astro_codegen
+
+# Review snapshot changes after a diff
+cargo insta review
+```
+
+Snapshot tests use [`insta`](https://insta.rs/). To add a case, drop a new `.astro` fixture in `crates/astro_codegen/tests/fixtures/`, run `cargo test -p astro_codegen`, then review the generated `.snap` with `cargo insta review`. Benchmarks use `divan` under `crates/*/benches/`.
+
+## TypeScript tests
+
+```shell
+# Build the addon first, then run the package tests
+pnpm run build:napi
+pnpm test
+```
+
+`pnpm test` runs the `@astrojs/compiler-rs` suite (`node --import tsx --test 'packages/compiler/test/**/*.ts'`). The NAPI crate has its own binding tests, run with `pnpm test` from `crates/astro_napi`.
+
+# Compiler Quick Reference
+
+The compilation pipeline has three stages:
+
+1. **Parsing** — Astro's fork of `oxc_parser` (the [oxc fork](https://github.com/withastro/oxc) linked above) parses a `.astro` file into an AST. Upstream oxc only parses JS/TS; the fork adds the `.astro` grammar.
+2. **Scanning** — `AstroScanner` pre-analyzes the AST to collect metadata (hydrated components, hoisted scripts, styles).
+3. **Printing** — `AstroCodegen` generates Astro-runtime-compatible JavaScript from the AST.
+
+The public entry points are re-exported from [`crates/astro_codegen/src/lib.rs`](./crates/astro_codegen/src/lib.rs) (`transform`, `AstroCodegen`, `AstroScanner`, `TransformOptions`).
+
+# Deep Dives
+
+- The `.astro` language surface the compiler accepts is specified in [`docs/SYNTAX_SPEC.md`](./docs/SYNTAX_SPEC.md). Read it before changing parsing or printing behavior.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ napi-derive = "3"
 
 # External
 cow-utils = "0.1.3"
-lightningcss = { version = "1.0.0-alpha.70", features = ["visitor", "into_owned"], default-features = false }
+lightningcss = { version = "1.0.0-alpha.72", features = ["visitor", "into_owned"], default-features = false }
 divan = "0.1"
 rustc-hash = "2"
 insta = "1.43.2"

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
   "files": {
     "includes": [
       "**",
@@ -29,7 +29,8 @@
   "assist": {
     "actions": {
       "source": {
-        "organizeImports": "off"
+        "organizeImports": "off",
+        "useSortedPackageJson": "on"
       }
     }
   },
@@ -40,7 +41,7 @@
       "test": "recommended"
     },
     "rules": {
-      "recommended": false,
+      "preset": "none",
       "style": {
         "useNodejsImportProtocol": "error",
         // Enforce separate type imports for type-only imports to avoid bundling unneeded code

--- a/crates/astro_codegen/src/css_scoping.rs
+++ b/crates/astro_codegen/src/css_scoping.rs
@@ -21,7 +21,7 @@ use lightningcss::visitor::{Visit, VisitTypes, Visitor};
 
 use crate::ScopedStyleStrategy;
 
-fn parser_options<'a, 'i>() -> ParserOptions<'a, 'i> {
+fn parser_options<'a>() -> ParserOptions<'a> {
     ParserOptions {
         flags: ParserFlags::NESTING,
         error_recovery: true,

--- a/crates/astro_napi/package.json
+++ b/crates/astro_napi/package.json
@@ -10,33 +10,28 @@
   ],
   "homepage": "https://astro.build",
   "bugs": "https://github.com/withastro/compiler/issues",
-  "license": "MIT",
-  "author": "Astro contributors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/withastro/compiler-rs.git",
     "directory": "crates/astro_napi"
   },
+  "license": "MIT",
+  "author": "Astro contributors",
+  "type": "module",
+  "main": "index.js",
   "files": [
     "index.d.ts",
     "index.js",
     "browser.js",
     "webcontainer-fallback.cjs"
   ],
-  "type": "module",
-  "main": "index.js",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/",
-    "provenance": true
-  },
   "scripts": {
     "artifacts": "napi artifacts",
+    "build": "napi build --esm --platform --features allocator --release",
+    "postbuild": "node patch-binding.js",
     "build-dev": "napi build --esm --platform",
     "postbuild-dev": "node patch-binding.js",
     "build-test": "pnpm run build-dev",
-    "build": "napi build --esm --platform --features allocator --release",
-    "postbuild": "node patch-binding.js",
     "prepublishOnly": "napi prepublish -t npm",
     "test": "node --import tsx --test ./test/*.test.ts",
     "version": "napi version"
@@ -46,6 +41,14 @@
     "@napi-rs/cli": "^3",
     "@napi-rs/wasm-runtime": "^1.1.1",
     "@types/node": "^22"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "registry": "https://registry.npmjs.org/"
   },
   "napi": {
     "binaryName": "astro",
@@ -66,8 +69,5 @@
         "fs": false
       }
     }
-  },
-  "engines": {
-    "node": "^20.19.0 || >=22.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,14 @@
     "type": "git",
     "url": "git+https://github.com/withastro/compiler-rs.git"
   },
+  "workspaces": [
+    "packages/*",
+    "crates/astro_napi"
+  ],
   "scripts": {
-    "build:napi": "pnpm --filter ./crates/astro_napi run build-dev",
-    "build:compiler": "pnpm --filter @astrojs/compiler-rs run build",
     "build:all": "pnpm run build:napi && pnpm run build:compiler",
+    "build:compiler": "pnpm --filter @astrojs/compiler-rs run build",
+    "build:napi": "pnpm --filter ./crates/astro_napi run build-dev",
     "format": "pnpm run format:code && pnpm run format:imports",
     "format:ci": "pnpm run format:code:ci && pnpm run format:imports:ci",
     "format:code": "biome format --write && cargo fmt",
@@ -23,19 +27,15 @@
     "test": "node --import tsx --test 'packages/compiler/test/**/*.ts'",
     "test:ci": "pnpm run test"
   },
-  "packageManager": "pnpm@10.29.3",
-  "workspaces": [
-    "packages/*",
-    "crates/astro_napi"
-  ],
   "devDependencies": {
-    "@biomejs/biome": "2.3.15",
+    "@biomejs/biome": "2.5.4",
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",
     "sass": "^1.97.3",
     "tsx": "^4.21.0",
     "typescript": "~5.9.3"
   },
+  "packageManager": "pnpm@10.29.3",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,29 +1,15 @@
 {
   "name": "@astrojs/compiler-rs",
-  "author": "withastro",
-  "license": "MIT",
-  "type": "module",
-  "bugs": "https://github.com/withastro/compiler-rs/issues",
-  "homepage": "https://astro.build",
   "version": "0.3.1",
-  "scripts": {
-    "build": "tsdown && publint"
-  },
-  "main": "./dist/index.mjs",
+  "homepage": "https://astro.build",
+  "bugs": "https://github.com/withastro/compiler-rs/issues",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/withastro/compiler-rs.git"
   },
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  },
-  "files": [
-    "dist",
-    "types.d.ts",
-    "utils.d.ts",
-    "async.d.ts"
-  ],
+  "license": "MIT",
+  "author": "withastro",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
@@ -39,17 +25,31 @@
     },
     "./package.json": "./package.json"
   },
+  "main": "./dist/index.mjs",
+  "files": [
+    "dist",
+    "types.d.ts",
+    "utils.d.ts",
+    "async.d.ts"
+  ],
+  "scripts": {
+    "build": "tsdown && publint"
+  },
   "dependencies": {
     "@astrojs/compiler-binding": "workspace:*"
   },
   "devDependencies": {
     "@jridgewell/trace-mapping": "^0.3.16",
     "@types/node": "^22",
+    "publint": "^0.3.21",
     "tsdown": "^0.22.3",
-    "typescript": "~5.5.3",
-    "publint": "^0.3.21"
+    "typescript": "~5.5.3"
   },
   "engines": {
     "node": ">=22.12.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.3.15
-        version: 2.3.15
+        specifier: 2.5.4
+        version: 2.5.4
       '@changesets/changelog-github':
         specifier: ^0.5.2
         version: 0.5.2
@@ -91,59 +91,59 @@ packages:
     resolution: {integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
-  '@biomejs/biome@2.3.15':
-    resolution: {integrity: sha512-u+jlPBAU2B45LDkjjNNYpc1PvqrM/co4loNommS9/sl9oSxsAQKsNZejYuUztvToB5oXi1tN/e62iNd6ESiY3g==}
+  '@biomejs/biome@2.5.4':
+    resolution: {integrity: sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.3.15':
-    resolution: {integrity: sha512-SDCdrJ4COim1r8SNHg19oqT50JfkI/xGZHSyC6mGzMfKrpNe/217Eq6y98XhNTc0vGWDjznSDNXdUc6Kg24jbw==}
+  '@biomejs/cli-darwin-arm64@2.5.4':
+    resolution: {integrity: sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.3.15':
-    resolution: {integrity: sha512-RkyeSosBtn3C3Un8zQnl9upX0Qbq4E3QmBa0qjpOh1MebRbHhNlRC16jk8HdTe/9ym5zlfnpbb8cKXzW+vlTxw==}
+  '@biomejs/cli-darwin-x64@2.5.4':
+    resolution: {integrity: sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.3.15':
-    resolution: {integrity: sha512-SSSIj2yMkFdSkXqASzIBdjySBXOe65RJlhKEDlri7MN19RC4cpez+C0kEwPrhXOTgJbwQR9QH1F4+VnHkC35pg==}
+  '@biomejs/cli-linux-arm64-musl@2.5.4':
+    resolution: {integrity: sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.3.15':
-    resolution: {integrity: sha512-FN83KxrdVWANOn5tDmW6UBC0grojchbGmcEz6JkRs2YY6DY63sTZhwkQ56x6YtKhDVV1Unz7FJexy8o7KwuIhg==}
+  '@biomejs/cli-linux-arm64@2.5.4':
+    resolution: {integrity: sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.3.15':
-    resolution: {integrity: sha512-dbjPzTh+ijmmNwojFYbQNMFp332019ZDioBYAMMJj5Ux9d8MkM+u+J68SBJGVwVeSHMYj+T9504CoxEzQxrdNw==}
+  '@biomejs/cli-linux-x64-musl@2.5.4':
+    resolution: {integrity: sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.3.15':
-    resolution: {integrity: sha512-T8n9p8aiIKOrAD7SwC7opiBM1LYGrE5G3OQRXWgbeo/merBk8m+uxJ1nOXMPzfYyFLfPlKF92QS06KN1UW+Zbg==}
+  '@biomejs/cli-linux-x64@2.5.4':
+    resolution: {integrity: sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.3.15':
-    resolution: {integrity: sha512-puMuenu/2brQdgqtQ7geNwQlNVxiABKEZJhMRX6AGWcmrMO8EObMXniFQywy2b81qmC+q+SDvlOpspNwz0WiOA==}
+  '@biomejs/cli-win32-arm64@2.5.4':
+    resolution: {integrity: sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.3.15':
-    resolution: {integrity: sha512-kDZr/hgg+igo5Emi0LcjlgfkoGZtgIpJKhnvKTRmMBv6FF/3SDyEV4khBwqNebZIyMZTzvpca9sQNSXJ39pI2A==}
+  '@biomejs/cli-win32-x64@2.5.4':
+    resolution: {integrity: sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -1825,39 +1825,39 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0
       '@babel/helper-validator-identifier': 8.0.2
 
-  '@biomejs/biome@2.3.15':
+  '@biomejs/biome@2.5.4':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.3.15
-      '@biomejs/cli-darwin-x64': 2.3.15
-      '@biomejs/cli-linux-arm64': 2.3.15
-      '@biomejs/cli-linux-arm64-musl': 2.3.15
-      '@biomejs/cli-linux-x64': 2.3.15
-      '@biomejs/cli-linux-x64-musl': 2.3.15
-      '@biomejs/cli-win32-arm64': 2.3.15
-      '@biomejs/cli-win32-x64': 2.3.15
+      '@biomejs/cli-darwin-arm64': 2.5.4
+      '@biomejs/cli-darwin-x64': 2.5.4
+      '@biomejs/cli-linux-arm64': 2.5.4
+      '@biomejs/cli-linux-arm64-musl': 2.5.4
+      '@biomejs/cli-linux-x64': 2.5.4
+      '@biomejs/cli-linux-x64-musl': 2.5.4
+      '@biomejs/cli-win32-arm64': 2.5.4
+      '@biomejs/cli-win32-x64': 2.5.4
 
-  '@biomejs/cli-darwin-arm64@2.3.15':
+  '@biomejs/cli-darwin-arm64@2.5.4':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.3.15':
+  '@biomejs/cli-darwin-x64@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.3.15':
+  '@biomejs/cli-linux-arm64-musl@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.3.15':
+  '@biomejs/cli-linux-arm64@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.3.15':
+  '@biomejs/cli-linux-x64-musl@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.3.15':
+  '@biomejs/cli-linux-x64@2.5.4':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.3.15':
+  '@biomejs/cli-win32-arm64@2.5.4':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.3.15':
+  '@biomejs/cli-win32-x64@2.5.4':
     optional: true
 
   '@changesets/apply-release-plan@7.0.14':


### PR DESCRIPTION
## Changes

This PR adds a `AGENTS.md` file to the repository, plus a comment skill to instruct agents to how to properly document the code.

The behaviour is largely taken from what we have in our core repository.

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
