### PR TITLE
feat: auto-triage bot

### DIFF
--- a/.agents/skills/pr-writer/SKILL.md
+++ b/.agents/skills/pr-writer/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: pr-writer
+description: Write pull request titles and bodies for compiler-rs that follow the repository PR template. Trigger whenever asked to create, open, or draft a PR, or to write or update a PR title, body, summary, or description.
+---
+
+# PR Writer
+
+Produce a reviewer-friendly title and a body that matches this repository's
+[`PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md) exactly.
+
+When invoked by the triage bot, you are given the issue and the fix branch and
+asked to **return only the title and body** — do not open the PR yourself.
+
+## Title
+
+- Plain-language description of the outcome, the way a person writes it in a
+  review queue.
+- No conventional-commit prefixes (`fix:`, `feat:`) and no scopes
+  (`fix(codegen): ...`).
+- Concise and specific.
+
+## Body
+
+Use these three sections, in this order, and keep all three even when a section
+is short — the template requires it:
+
+```md
+## Changes
+
+- <What behavior changed and why it matters>
+- <Key implementation detail a reviewer should know>
+
+Closes #<issue-number>
+
+## Testing
+
+- <The regression fixture or test added, and what it asserts>
+
+## Docs
+
+- <Docs impact, or one sentence on why none is needed>
+```
+
+### Changes
+
+Describe the behavior change and how the fix works at a reviewer-useful level:
+what `.astro` input was miscompiled (or crashed) and what the compiler now emits
+instead. Include `Closes #<issue-number>` so merging closes the issue. Do not
+list "added a test" or "added a changeset" here — those are process, not
+behavior.
+
+### Testing
+
+Name the regression test that guards the fix and what it covers — e.g. the
+snapshot fixture `crates/astro_codegen/tests/fixtures/_<issue#>_<desc>.astro`, a
+`compile_astro(...)` unit test, or a `packages/compiler/test/**` case. State
+what output it now asserts. Do not report that the suite passes (CI shows that)
+or which commands you ran.
+
+### Docs
+
+`docs/SYNTAX_SPEC.md` is the only in-repo documentation. If the fix changes the
+documented `.astro` surface, note the update; otherwise say why none is needed
+(e.g. "bug fix only, emitted output now matches the spec").
+
+## Brevity
+
+Default to 1-2 bullets per section. A reviewer should absorb the whole body in
+under 30 seconds for a typical patch.
+
+## Self-check before returning
+
+- Title is reviewer-friendly, not commit-style.
+- All three template sections are present.
+- `Closes #<issue-number>` is in the body.
+- `Testing` names the regression test; `Docs` states an explicit decision.
+- A changeset already exists in `.changeset/` (created during the fix). If it is
+  missing, flag that rather than describing it in the body.

--- a/.agents/skills/triage/SKILL.md
+++ b/.agents/skills/triage/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: triage
+description: Triage a compiler-rs bug report. Reproduces the bug as a minimal `.astro` input, diagnoses the root cause in the Rust codegen, verifies whether the behavior is intentional, and attempts a fix. Use when asked to "triage issue #1234", "triage this bug", or similar.
+---
+
+# Triage
+
+Triage a `@astrojs/compiler-rs` bug report: reproduce the bug, diagnose the root
+cause, verify whether the behavior is intentional, and attempt a fix.
+
+This project is the Astro compiler: it transforms `.astro` source into
+JavaScript. A bug is almost always one of two things:
+
+- **Wrong output** — `transform` returns, but the emitted JS (or `map`, `scope`,
+  component metadata) differs from what it should be.
+- **A crash** — `transform` panics on some input (in a release build this
+  aborts the process; in tests it fails the test).
+
+There is no dev server, no browser, no user application to run. The whole bug
+lives in the `.astro` input and the compiler output.
+
+## How this skill is invoked
+
+The triage harness runs this skill **once per stage**, passing a `step` arg and
+an `instructions` arg. Run **only** the stage named by `step`, then return its
+structured result. Do not advance to the next stage yourself, and do not spawn
+sub-agents — the harness drives the sequence and calls you again for the next
+stage.
+
+| `step`      | Follow                       | Return |
+| ----------- | ---------------------------- | ------ |
+| `reproduce` | [reproduce.md](reproduce.md) | `reproducible` (bool), `skipped` (bool), `skippedReason` (one of the exact tokens in reproduce.md, or null) |
+| `diagnose`  | [diagnose.md](diagnose.md)   | `confidence` (`high`/`medium`/`low`, or null if not attempted) |
+| `verify`    | [verify.md](verify.md)       | `verdict` (`bug`/`intended-behavior`/`unclear`), `confidence` (`high`/`medium`/`low`) |
+| `fix`       | [fix.md](fix.md)             | `fixed` (bool), `commitMessage` (string, or null) |
+
+The stages share one working tree that persists between calls, but each stage
+starts with no memory of the previous one. Carry context forward by writing and
+re-reading **`triage/current/report.md`**: reproduce creates it, and every later
+stage reads it and appends to it. `triage/` is gitignored, so anything scratched
+there never lands on the fix branch.
+
+## Args
+
+- **`step`** — Which stage to run (see the table above).
+- **`issueDetails`** — The GitHub issue payload (title, body, comments). Use it
+  directly as the bug report. If absent, fetch it with
+  `gh issue view <number> --comments`.
+- **`issueNumber`** — The issue number. Passed for `reproduce` (it goes in the
+  regression-fixture filename); later stages read paths from `report.md`.
+- **`instructions`** — A harness reminder to run only the current stage.
+
+## What the harness does around you
+
+The harness has already checked out the repo on a fix branch. After the `fix`
+stage it stages, commits, and pushes any worktree changes, and — when a fix
+landed — opens the pull request (via the `pr-writer` skill) and manages the
+issue/PR labels. **Never commit, push, or open a PR yourself.** Leave the correct
+files in the working tree (see fix.md) and return your result; anything left in
+the tree that is not gitignored will be committed, so clean up scratch work.
+
+## Don't get stuck on infrastructure
+
+If the toolchain won't build, a dependency won't install, or a tool is missing —
+bail out after 2 attempts and record what you have in `report.md`. A partial
+report with solid findings beats burning the time budget fighting the
+environment.

--- a/.agents/skills/triage/diagnose.md
+++ b/.agents/skills/triage/diagnose.md
@@ -1,0 +1,106 @@
+# Diagnose
+
+Find the root cause of a reproduced bug in the compiler's Rust source.
+
+**CRITICAL: You MUST always read `report.md` and append to it before finishing,
+regardless of outcome. Even if the investigation is inconclusive, always record
+what you found. Downstream skills depend on `report.md`.**
+
+**SCOPE: Diagnosis only. Do NOT fix the bug or write a regression test. Do not
+spawn sub-agents.**
+
+## Prerequisites
+
+- **`triageDir`** — Fixed scratch directory `triage/current` (gitignored). The
+  harness does not pass this; always use `triage/current`.
+- **`report.md`** — At `triage/current/report.md`, written by reproduce. Full
+  prior context.
+- **`issueDetails`** — The GitHub issue payload, if you need to re-read it.
+
+## The compilation pipeline
+
+Trace the defect to the stage that owns it:
+
+1. **Parse** — Astro's fork of `oxc_parser` turns `.astro` into an AST. This
+   lives in the pinned [`withastro/oxc`](https://github.com/withastro/oxc) fork,
+   **not in this repo**. A parse-stage bug (malformed AST, a parse error the
+   harness prints as `Parse errors: ...`, wrong spans) cannot be fixed here —
+   note it and hand off; the fix step documents the out-of-repo cause.
+2. **Scan** — `AstroScanner` (`crates/astro_codegen/src/scanner.rs`) walks the
+   AST once and collects metadata: hydrated / client-only / server components,
+   hoisted scripts, styles, `uses_astro_global`, `has_await`, etc.
+3. **Print** — `AstroCodegen` (`crates/astro_codegen/src/printer/`) emits the
+   runtime JS from the AST + scan results.
+4. **Reprint** — `build()` runs the printed JS back through `oxc_codegen` to
+   strip TypeScript and normalize formatting. **The final `code` string comes
+   from this reprint**, so tab indentation and multi-line object shape are set
+   here, not by the printer's own `print`/`println`. Do not chase a formatting
+   difference into the printer when the reprint produced it.
+
+## Step 1: Review the reproduction
+
+Read `report.md`. **Skip if not reproduced:** if it shows the bug was not
+reproduced or was skipped, append `DIAGNOSIS SKIPPED: no reproduction` and
+return `confidence: null`.
+
+Re-run to see the failure yourself:
+
+```bash
+INSTA_UPDATE=new cargo test -p astro_codegen snapshots   # then read the fixture's .snap.new
+```
+
+## Step 2: Locate the source
+
+Map the symptom to the owning module under `crates/astro_codegen/src/`:
+
+- **`scanner.rs`** — wrong/missing component metadata, hoisted scripts, `has_await`
+- **`printer/mod.rs`** — top-level codegen, `$$metadata`, component wrapper, the
+  `oxc_codegen` reprint
+- **`printer/elements.rs`** — element/attribute/tag emission
+- **`printer/expressions.rs`** — `{...}` expressions, template literals
+- **`printer/escape.rs`** — string/attribute escaping
+- **`printer/whitespace.rs`** — whitespace collapsing
+- **`css_scoping.rs`**, **`style.rs`** — scope hashing and `<style>` handling
+- **`options.rs`** — how a `TransformOptions` value changes output
+- **`diagnostic.rs`** — diagnostics (note: codegen currently emits none of its
+  own; a missing-diagnostic bug is an unimplemented feature, not a regression)
+
+## Step 3: Instrument
+
+Add temporary tracing and run the narrowest test:
+
+```rust
+eprintln!("[TRIAGE] node = {node:#?}");
+dbg!(&scan_result.hydrated_components);
+```
+
+```bash
+cargo test -p astro_codegen <specific_test_name> -- --nocapture
+```
+
+Iterate until you understand which code path runs, what data flows through it,
+and where it diverges from correct behavior. Then **revert every instrumentation
+edit** with `git checkout -- <file>` — debug output must not leak downstream.
+
+## Step 4: Identify the root cause
+
+Document:
+
+1. **Which file(s)** and line(s) hold the defect
+2. **What the code does wrong** — the specific logic error
+3. **Why it produces the observed output/crash**
+4. **What the fix should be** — high level
+
+Consider whether it is a recently introduced regression, whether it affects
+adjacent constructs, and what edge cases a fix must respect (the 380+ existing
+snapshot fixtures encode behavior you must not break).
+
+**Tone:** describe the cause factually. A missing branch is a missing branch,
+not a "critical flaw." The goal is to orient a maintainer, not to alarm.
+
+## Step 5: Append to `report.md`
+
+Add a diagnosis section: root cause, affected files with line numbers, the code
+path, what your instrumentation showed, the suggested fix approach, and a
+**confidence** level (`high`, `medium`, or `low`) with any caveats. If the cause
+is in the `oxc` parser fork, say so explicitly and set confidence accordingly.

--- a/.agents/skills/triage/fix.md
+++ b/.agents/skills/triage/fix.md
@@ -1,0 +1,139 @@
+# Fix
+
+Develop and verify a fix for a diagnosed compiler bug.
+
+**CRITICAL: You MUST always read `report.md` and append to it before finishing,
+regardless of outcome. Even if the fix fails, record what you tried.**
+
+**SCOPE: Do not spawn sub-agents. Do not commit or push — the orchestrator
+stages, commits, and (when a fix lands) opens the PR.**
+
+## Prerequisites
+
+- **`triageDir`** — Fixed scratch directory `triage/current` (gitignored). The
+  harness does not pass this; always use `triage/current`.
+- **`report.md`** — At `triage/current/report.md`. Root cause and suggested
+  approach.
+- **`issueDetails`** — The GitHub issue payload, if needed.
+
+Follow the repo conventions in `AGENTS.md` (Rust edition 2024, 4-space indent)
+and the [`writing-comments`](../writing-comments/SKILL.md) skill for any comment
+you add.
+
+## Step 1: Decide the path
+
+Read `report.md`.
+
+- **Skip if unusable:** not reproduced, skipped, or the cause is in the `oxc`
+  parser fork (out of this repo) → append `FIX SKIPPED: <reason>`, return
+  `fixed: false`. Do not guess a fix you cannot verify here.
+- **Low confidence (`low`/`null`) or no clear root cause → breadcrumb path**
+  (Step 6). Do not force a speculative code change.
+- **Medium/high confidence with a clear cause → fix path** (Steps 2-5).
+
+The tree may be dirty from earlier steps. Run `git status`; revert any leftover
+instrumentation before starting (`git checkout -- <file>`).
+
+## Step 2: Implement the fix
+
+Edit source under `crates/astro_codegen/src/`. Keep it minimal:
+
+- Change only what the root cause requires; do not refactor unrelated code or
+  restyle adjacent lines.
+- Respect the 380+ existing snapshot fixtures and the unit tests — they encode
+  behavior you must not regress.
+- Watch edge cases the diagnosis flagged (unusual attributes, nesting, options).
+
+## Step 3: Verify against the reproduction
+
+Rebuild and re-run the reproduction:
+
+```bash
+INSTA_UPDATE=new cargo test -p astro_codegen snapshots   # regenerates the fixture's .snap.new
+cat crates/astro_codegen/tests/fixtures/_<issue#>_<desc>.snap.new
+```
+
+Confirm the output is now correct. For a wrapper-layer fix, rebuild the addon
+and exercise the JS path:
+
+```bash
+pnpm run build:napi && pnpm test
+```
+
+## Step 4: Lock in the regression test
+
+The `.astro` fixture from reproduce becomes the permanent regression test.
+Accept its snapshot once the output is correct:
+
+```bash
+cargo insta accept                            # writes .snap from the pending .snap.new
+cargo test -p astro_codegen                   # confirm green
+```
+
+Check `git status` shows only your intended `.astro` + `.snap` (and source
+changes) — no stray accepted snapshots from unrelated tests. If a fixture cannot
+capture the bug (e.g. it needs options the harness lacks), add a unit test with
+`compile_astro(...)` in the relevant `crates/astro_codegen/src/printer/*_tests.rs`
+module, or a `packages/compiler/test/**/*.ts` case instead, and say why in
+`report.md`.
+
+## Step 5: Guard the whole suite
+
+Do not break anything else:
+
+```bash
+cargo test                     # full Rust suite
+cargo clippy -- -D warnings    # CI treats any warning as an error
+cargo fmt                      # format Rust
+```
+
+If you touched the TypeScript wrapper, also run `pnpm run build:napi && pnpm test`
+(the addon must be rebuilt for the JS layer to see Rust changes) and
+`pnpm lint` / `pnpm format` for Biome.
+
+Fix any failure before proceeding. If your change legitimately alters other
+snapshots, re-examine whether that is correct — an unexpected snapshot flip is
+usually a sign the fix is too broad.
+
+## Step 6: Breadcrumb path (low confidence / no fix)
+
+When you cannot land a confident fix, leave a useful trail instead of a wrong
+patch:
+
+1. Keep the reproduce fixture **without** an accepted `.snap` so the snapshot
+   test fails and documents the bug, **or** add a `#[test]` asserting the
+   expected output that currently fails.
+2. Add up to 2-3 `// TRIAGE:` comments at the most relevant source lines to
+   orient a maintainer.
+3. Append the suspect files/paths and your reasoning to `report.md`.
+4. Return `fixed: false`. Skip Step 7.
+
+## Step 7: Changeset (fix path only)
+
+Only when the fix succeeded, add `.changeset/<two-random-words>.md` bumping both
+fixed-group packages at `patch` (bug fixes are patches):
+
+```md
+---
+"@astrojs/compiler-binding": patch
+"@astrojs/compiler-rs": patch
+---
+
+<One sentence describing the user-facing fix.>
+```
+
+## Step 8: Append to `report.md`
+
+Record: what changed and why, the `git diff` of the source, verification results
+(does the reproduction now pass?), the regression test added (path + what it
+asserts, or why none), the changeset filename, any alternatives/trade-offs, and
+— if `fixed: false` — what you tried and why it did not work. Return `fixed` and
+a short `commitMessage`.
+
+## Step 9: Clean the working tree
+
+1. `git status` and review every changed file.
+2. Revert anything not part of the fix: `eprintln!`/`dbg!` instrumentation,
+   scratch files, changes made only for diagnosis (`git checkout -- <file>`).
+3. Confirm only the fix, the regression fixture/test, and the changeset remain.
+4. Do NOT commit or push. `triage/` is gitignored and will not appear.

--- a/.agents/skills/triage/reproduce.md
+++ b/.agents/skills/triage/reproduce.md
@@ -1,0 +1,152 @@
+# Reproduce
+
+Reproduce a `@astrojs/compiler-rs` bug: turn the report into a minimal `.astro`
+input that demonstrates wrong compiler output (or a crash).
+
+**CRITICAL: You MUST always write `report.md` to the triage directory before
+finishing, regardless of outcome. Even if you cannot reproduce, hit errors, or
+need to skip — always write `report.md`. Downstream skills have NO access to the
+original issue; `report.md` is their only source of context. If you finish
+without writing it, the pipeline fails silently.**
+
+**SCOPE: Reproduction only. Do NOT diagnose, fix, or add a permanent regression
+test here. Do not spawn sub-agents.**
+
+## Prerequisites
+
+- **`triageDir`** — Fixed scratch directory `triage/current` (gitignored, shared
+  across stages). The harness does not pass this; always use `triage/current` so
+  the later stages, which are not given the issue number, find your `report.md`.
+- **`issueDetails`** — The GitHub issue payload. If missing, run
+  `gh issue view <number> --comments` to load it.
+
+## What a reproduction looks like here
+
+The product is a compiler: `.astro` in, JavaScript out. A reproduction is a
+**minimal `.astro` source** plus a statement of what is wrong with the output.
+Classify the bug:
+
+- **Wrong output** — the emitted `code` (or `map`, `scope`, `css`, or a
+  `*Components`/`containsHead`/`propagation` field) differs from what it should
+  be.
+- **Crash** — `transform` panics on the input.
+
+Reporters often attach a whole Astro project or a StackBlitz link. That is a
+symptom carrier, not the reproduction. **Reduce it** to the smallest `.astro`
+snippet whose compiler output shows the defect. If the failure depends on a
+`TransformOptions` value (e.g. `compact`, `filename`, `resolvePath`), record it.
+
+## Step 1: Confirm the report
+
+Read `issueDetails`. Extract:
+
+- The `.astro` source (or the snippet inside the linked project) that triggers it
+- What the reporter expected the output/behavior to be
+- What actually happens (error text, wrong JS, panic message)
+- Any `TransformOptions` in play (from `astro.config`, the reporter's call, etc.)
+
+## Step 2: Check for early-exit conditions
+
+If any condition below is met, skip to Step 5, write `report.md`, and stop.
+Report the reason using **one of these exact tokens** (the orchestrator only
+understands this fixed set):
+
+- **`not-actionable`** — Not a bug report: feature request, question, or a
+  request to change intended output. (→ `triage: not actionable`)
+- **`missing-details`** — No `.astro` input is given and none can be derived,
+  or there is no statement of the expected output. Both are required to
+  reproduce and later verify. (→ `triage: needs reproduction`)
+- **`host-specific`** — Reused here to mean **out of scope for the compiler**:
+  the defect is in the Astro runtime/renderer, an adapter, a bundler
+  integration, or another package — the compiler's JS output is correct. If you
+  can show the emitted JS is right and the fault is downstream, exit with this.
+  (→ `triage: skipped`)
+- **`unsupported-version`** — The issue targets the legacy Go `@astrojs/compiler`
+  (not `@astrojs/compiler-rs`), or a version/surface this repo does not produce.
+  (→ `triage: skipped`)
+- **`maintainer-override`** — A maintainer commented that this should not be
+  auto-triaged. Check `authorAssociation` on comments for `MEMBER`,
+  `COLLABORATOR`, or `OWNER`. (→ `triage: skipped`)
+
+**Comment handling:** an early exit is only valid if no later comment
+invalidates it (e.g. a follow-up comment adds the missing `.astro`, or shows the
+fault really is in compiler output). Re-read the full thread before exiting.
+
+## Step 3: Build the minimal input
+
+Prefer the **Rust snapshot harness** — it is the fastest path and needs no
+native-addon rebuild.
+
+1. Write the minimal source to a fixture:
+   `crates/astro_codegen/tests/fixtures/_<issue#>_<short_desc>.astro`
+   (the `_<issue#>_` prefix is this repo's convention for regression fixtures).
+2. If the bug requires non-default options, add `// @config` lines at the very
+   top. Only `compact=html|jsx|false` is supported by the harness today; for any
+   other option, reproduce through the JS API instead (see below).
+
+Keep the source as small as possible — only what is needed to trigger the
+defect.
+
+## Step 4: Observe the actual output
+
+Run the snapshot test to generate output without committing to a baseline.
+Under CI, `insta` will not write pending snapshots unless you force it, so set
+`INSTA_UPDATE=new`:
+
+```bash
+INSTA_UPDATE=new cargo test -p astro_codegen snapshots
+```
+
+A brand-new fixture has no `.snap`, so the test reports a new snapshot (it exits
+non-zero — that is expected) and writes a pending `<name>.snap.new` next to the
+fixture. `*.snap.new` is gitignored. Read it to see the **actual** compiler
+output:
+
+```bash
+cat crates/astro_codegen/tests/fixtures/_<issue#>_<short_desc>.snap.new
+```
+
+- **Wrong output:** compare the actual output to the reporter's expected output.
+  Confirm the difference is real and matches the report.
+- **Crash:** a panic in `transform` aborts the test run (the harness only
+  converts *parse* errors into text). Re-run with `RUST_BACKTRACE=1` and capture
+  the panic message and backtrace.
+
+**Do not accept the snapshot** (`cargo insta accept` / `INSTA_UPDATE`) here —
+that belongs to the fix step. Leave the `.astro` fixture in place for downstream
+steps; the pending `.snap.new` is ignored by git.
+
+### When the Rust harness is not enough
+
+Some bugs live in the TypeScript wrapper (`resolvePath`, `preprocessStyles`) or
+need options the harness cannot set. Reproduce through the JS API instead:
+
+```bash
+pnpm run build:napi   # rebuild the native addon; it does NOT hot-reload
+node --input-type=module -e "import { transform } from '@astrojs/compiler-rs'; \
+  const r = await transform(SRC, { /* options */ }); console.log(r.code);"
+```
+
+The addon must be rebuilt after any Rust change before the JS layer sees it.
+
+### False-positive guard
+
+Confirm the defect is the reported one: a trivially-correct variant of the input
+should compile cleanly, so you know the difference is caused by the reported
+construct and not your setup.
+
+## Step 5: Write `report.md`
+
+Write `report.md` to `triageDir`. This is context for the next stages, not a
+human comment — include too much rather than too little. Cover:
+
+- Original issue title, body, and any clarifying comments
+- The minimal `.astro` source and any required `TransformOptions` / `@config`
+- The fixture path you created (if any)
+- **Actual** output (from `.snap.new` or the API) and the **expected** output,
+  or the full panic message + backtrace for a crash
+- Outcome: **reproduced**, **not reproduced**, or **skipped** — and for skipped,
+  the exact token from Step 2 and why
+- If you early-exit as `not-actionable`, `missing-details`, `host-specific`, or
+  `unsupported-version`, delete the stray `.astro` fixture you created so it does
+  not land on the branch.

--- a/.agents/skills/triage/verify.md
+++ b/.agents/skills/triage/verify.md
@@ -1,0 +1,106 @@
+# Verify
+
+Decide whether the reported behavior is an actual bug or the compiler working as
+intended.
+
+**CRITICAL: You MUST always read `report.md` and append your findings before
+finishing, regardless of outcome. Downstream skills depend on `report.md`.**
+
+**SCOPE: Verification only. Do NOT fix anything. Do not spawn sub-agents.**
+
+## Prerequisites
+
+- **`triageDir`** — Fixed scratch directory `triage/current` (gitignored). The
+  harness does not pass this; always use `triage/current`.
+- **`report.md`** — At `triage/current/report.md`. Full prior context.
+- **`issueDetails`** — The GitHub issue payload, if you need to re-read it.
+
+There is **no reference compiler** to diff against. Do not consult or clone the
+legacy Go `@astrojs/compiler`. Correctness is judged from the sources below.
+
+## Step 1: State the claim
+
+From `report.md`, extract the reporter's **expected output** and the **actual
+output**. The expected output is the claim you are testing: is it correct, or a
+misunderstanding of how the compiler is designed to emit code?
+
+## Step 2: Research intent
+
+Do not assume the reporter is right. Weigh these sources:
+
+### 2a. The syntax spec
+
+[`docs/SYNTAX_SPEC.md`](../../../docs/SYNTAX_SPEC.md) defines the `.astro`
+surface the compiler accepts and how it is meant to be emitted. If the spec
+describes the current output, the behavior is intended. If it promises the
+reporter's expected output, that supports a bug verdict.
+
+### 2b. The existing test corpus
+
+`crates/astro_codegen/tests/fixtures/*.snap` and the unit tests in
+`crates/astro_codegen/src/**` encode expected output that maintainers have
+already accepted. Check whether a fixture or test already asserts the current
+behavior:
+
+- If an existing snapshot deliberately shows the "wrong" output, it was likely a
+  conscious choice — lean toward intended-behavior.
+- If making the reporter's expected output pass would flip many unrelated
+  snapshots, the current behavior is probably a deliberate trade-off, not an
+  accident.
+
+### 2c. Source intent signals
+
+In `crates/astro_codegen/src/`, look for:
+
+- **Comments explaining "why"** — strong evidence of a deliberate choice,
+  especially ones citing the `oxc` fork or a linked issue.
+- **Explicit conditionals** that handle the reported case on purpose.
+- **Named options/constants** that gate the behavior.
+
+### 2d. History
+
+Run `git blame` on the lines `report.md` identified, read the introducing commit
+(`git show --no-patch <sha>`) and any referenced PR (`gh pr view <n>`). A
+rationale from the author is strong evidence of intent. Search prior discussion:
+
+```bash
+gh search issues "<keywords>"
+gh search prs "<keywords>"
+```
+
+A prior issue closed "by design" for the same behavior settles it.
+
+### 2e. Bug vs non-bug
+
+- A **bug** is behavior the author **did not know about or did not choose** — an
+  oversight, an unhandled construct, a regression.
+- A **non-bug** is behavior the author **knew about and chose** — a documented
+  limitation or trade-off — even if imperfect and even if the reporter's request
+  is reasonable. That is an enhancement, not a bug fix.
+
+The test is not "is the output nice?" but "did the author know about and choose
+it?" A `.astro` construct the compiler was never taught to handle is a bug; an
+output the spec or a code comment deliberately prescribes is intended.
+
+## Step 3: Verdict
+
+- **bug** — no comment/rationale, contradicts the spec, a clear regression, or a
+  construct that falls through unhandled by accident.
+- **intended-behavior** — the spec prescribes it, a comment/commit explains it,
+  an explicit branch handles it, or a prior issue closed it "by design." Reframe
+  the reporter's concern as a possible enhancement.
+- **unclear** — intent is genuinely ambiguous. Prefer this over guessing.
+
+## Step 4: Confidence
+
+- **high** — explicit spec text, code comments, or prior maintainer statements.
+- **medium** — reasonable evidence, some ambiguity.
+- **low** — mostly inference.
+
+## Step 5: Append to `report.md`
+
+Record: the claim, the verdict (`bug` / `intended-behavior` / `unclear`),
+confidence, and the specific evidence (spec sections, snapshot/test names, code
+comments, commits, prior issues/PRs). For `intended-behavior`, note the design
+rationale and the possible enhancement framing. For `bug`, explain why the
+behavior looks accidental.

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,92 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened, reopened, closed]
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+concurrency:
+  # One triage run per issue at a time. Queue rather than cancel, so the bot
+  # posting its own comment does not kill an in-flight run.
+  group: issue-triage-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    # Skip pull requests and the bot's own comments (which would self-trigger).
+    if: >-
+      github.repository_owner == 'withastro' &&
+      !github.event.issue.pull_request &&
+      (github.event.action != 'created' ||
+       (github.event.comment.user.login != 'astrobot-houston' &&
+        github.event.comment.user.login != 'github-actions[bot]'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read # Read the repo; branch pushes use FREDKBOT_GITHUB_TOKEN
+      issues: read # Read issue details for triage
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Configure Git identity
+        run: |
+          git config user.name "astrobot-houston"
+          git config user.email "fred+astrobot@astro.build"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: issue-triage-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install cargo-insta
+        uses: taiki-e/install-action@v2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tool: cargo-insta
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: latest
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build:all
+
+      - name: Run triagebot
+        # Requires a triagebot-action release that supports `auto-pr-on-fix`.
+        # Bump this pin to that release (or its commit SHA) before enabling.
+        uses: withastro/triagebot-action@v0.4.0
+        with:
+          read-token: ${{ secrets.GITHUB_TOKEN }}
+          write-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+          anthropic-api-key: ${{ secrets.CI_ANTHROPIC_API_KEY }}
+          triage-skill: .agents/skills/triage
+          pr-skill: .agents/skills/pr-writer
+          pr-skill-name: pr-writer
+          bot-logins: astrobot-houston
+          auto-pr-on-fix: true

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -80,11 +80,12 @@ jobs:
       - name: Run triagebot
         # Requires a triagebot-action release that supports `auto-pr-on-fix`.
         # Bump this pin to that release (or its commit SHA) before enabling.
-        uses: withastro/triagebot-action@v0.4.0
+        uses: withastro/triagebot-action@476b3c1de66f1ab42060b7ca58d590b34775fa39
         with:
           read-token: ${{ secrets.GITHUB_TOKEN }}
           write-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
-          anthropic-api-key: ${{ secrets.CI_ANTHROPIC_API_KEY }}
+          cloudflare-api-key: ${{ secrets.CLOUDFLARE_API_KEY }}
+          cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           triage-skill: .agents/skills/triage
           pr-skill: .agents/skills/pr-writer
           pr-skill-name: pr-writer

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Cargo.lock
 
 # insta pending snapshots
 *.snap.new
+
+# Automated triage reproduction projects (triagebot)
+/triage/


### PR DESCRIPTION
## Changes

This PR adds an automated triage workflow to the repository. 

It's heavily based on what we have in the core repository. We need a particular feature from the triage action, that's why the tag doesn't match production. 

Also, we need the to hook it to particular instance of workers and kimi, which isn't supported yet.

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
