### PR TITLE
feat: add Android ARM64 compiler binding target

### DIFF
--- a/.changeset/easy-towns-count.md
+++ b/.changeset/easy-towns-count.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler-binding": patch
+---
+
+Generate and publish the Android ARM64 compiler binding package.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,11 @@ jobs:
           - host: ubuntu-latest
             target: wasm32-wasip1-threads
             build: pnpm run build --target wasm32-wasip1-threads
+            
+          # -- Linux ARM64 -- 
+          - host: ubuntu-latest
+            target: aarch64-linux-android
+            build: pnpm run build --target aarch64-linux-android --use-napi-cross
 
     name: Build - ${{ matrix.settings.target }}
     runs-on: ${{ matrix.settings.host }}

--- a/crates/astro_napi/package.json
+++ b/crates/astro_napi/package.json
@@ -62,7 +62,8 @@
       "x86_64-apple-darwin",
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-linux-musl"
+      "x86_64-unknown-linux-musl",
+      "aarch64-linux-android"
     ],
     "wasm": {
       "browser": {


### PR DESCRIPTION
Closes #111 

Changes

- Add the "aarch64-linux-android" target to the N-API build targets.
- Add an Android ARM64 build job to the CI matrix.
- Enable generation and publishing of the "@astrojs/compiler-binding-android-arm64" package, which is already expected by the runtime loader.

Testing

- Built "astro_napi" for "aarch64-linux-android".
- Verified "napi create-npm-dirs" generates the "@astrojs/compiler-binding-android-arm64" package.
- Tested the generated binding on Android (Termux) by replacing the missing native module.
- Confirmed "astro dev" and production builds work successfully with the Android binding.

Docs

No documentation changes. This is a bug fix that enables an existing runtime code path for Android ARM64.