### PR TITLE
fix(codegen): preserve remaining attributes on define:vars scripts

### DIFF
--- a/.changeset/define-vars-preserve-attrs.md
+++ b/.changeset/define-vars-preserve-attrs.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/compiler-binding": patch
+"@astrojs/compiler-rs": patch
+---
+
+Fixes an issue where a `<script define:vars={...}>` element lost all of its other attributes (such as `data-astro-rerun`, `id`, or `nonce`) in the compiled output.

--- a/crates/astro_codegen/src/printer/mod.rs
+++ b/crates/astro_codegen/src/printer/mod.rs
@@ -1491,19 +1491,25 @@ impl<'a> AstroCodegen<'a> {
                         .collect()
                 };
 
+                // Print the opening tag with the element's remaining attributes
+                // (`type="module"`, `data-astro-rerun`, `id`, `nonce`, …) —
+                // print_html_attributes skips the compiler directives
+                // (define:vars, is:inline, …) itself.
+                self.print("<script");
+                self.print_html_attributes(&el.opening_element.attributes, None, false);
+                self.print(">");
+
                 if is_module {
                     // type="module" — no IIFE, just prepend $$defineScriptVars
-                    self.print("<script type=\"module\">");
+                    // (imports are illegal inside functions)
                     self.print("${");
                     self.print(runtime::DEFINE_SCRIPT_VARS);
                     self.print("(");
                     self.print(&define_vars_expr);
                     self.print(")}");
                     self.print(&escape_template_literal(&text_content));
-                    self.print("</script>");
                 } else {
                     // No type="module" — wrap in IIFE
-                    self.print("<script>");
                     self.print("(function(){${");
                     self.print(runtime::DEFINE_SCRIPT_VARS);
                     self.print("(");
@@ -1511,8 +1517,8 @@ impl<'a> AstroCodegen<'a> {
                     self.print(")}");
                     self.print(&escape_template_literal(&text_content));
                     self.print("})();");
-                    self.print("</script>");
                 }
+                self.print("</script>");
                 return;
             }
         }

--- a/crates/astro_codegen/tests/fixtures/define_vars_script_preserves_attributes.astro
+++ b/crates/astro_codegen/tests/fixtures/define_vars_script_preserves_attributes.astro
@@ -1,0 +1,9 @@
+---
+const foo = "bar";
+---
+<script is:inline data-astro-rerun define:vars={{ foo }}>
+  console.log(foo);
+</script>
+<script type="module" id="probe" nonce="abc" define:vars={{ foo }}>
+  console.log(foo);
+</script>

--- a/crates/astro_codegen/tests/fixtures/define_vars_script_preserves_attributes.snap
+++ b/crates/astro_codegen/tests/fixtures/define_vars_script_preserves_attributes.snap
@@ -1,0 +1,22 @@
+---
+source: crates/astro_codegen/tests/snapshots.rs
+input_file: crates/astro_codegen/tests/fixtures/define_vars_script_preserves_attributes.astro
+---
+import { render as $$render, createComponent as $$createComponent, defineScriptVars as $$defineScriptVars, createMetadata as $$createMetadata } from "http://localhost:3000/";
+export const $$metadata = $$createMetadata(import.meta.url, {
+	modules: [],
+	hydratedComponents: [],
+	clientOnlyComponents: [],
+	hydrationDirectives: new Set([]),
+	hoisted: []
+});
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+	const foo = "bar";
+	return $$render`<script data-astro-rerun>(function(){${$$defineScriptVars({ foo })}
+  console.log(foo);
+})();<\/script>
+<script type="module" id="probe" nonce="abc">${$$defineScriptVars({ foo })}
+  console.log(foo);
+<\/script>`;
+}, undefined, undefined);
+export default $$Component;


### PR DESCRIPTION
## Changes

Supersede https://github.com/withastro/compiler-rs/pull/95

Closes https://github.com/withastro/compiler-rs/issues/94

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
