### PR TITLE
ci: add step to broadcast compiler version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,3 +97,17 @@ jobs:
           publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get published compiler version
+        if: steps.changesets.outputs.published == 'true'
+        id: compiler
+        run: echo "version=$(node -p \"require('./crates/astro_napi/package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Update Astro playground compiler
+        if: steps.changesets.outputs.published == 'true'
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+          repository: withastro/astro-playground
+          event-type: astro-new-compiler
+          client-payload: '{"version":"${{ steps.compiler.outputs.version }}"}'


### PR DESCRIPTION
## Changes

We update the playground when a new version of the compiler is published

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
