### PR TITLE
fix(codegen): preserve newlines in slot content under compact mode

### DIFF
--- a/.changeset/slot-content-newlines.md
+++ b/.changeset/slot-content-newlines.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/compiler-binding": patch
+"@astrojs/compiler-rs": patch
+---
+
+Fixes newlines being lost in text passed directly between a component's tags, so a `<slot />` wrapped in `<pre>` keeps its line breaks.

--- a/crates/astro_codegen/src/printer/mod.rs
+++ b/crates/astro_codegen/src/printer/mod.rs
@@ -1327,13 +1327,10 @@ impl<'a> AstroCodegen<'a> {
     /// parent).  When compact is disabled, it falls through to `print_jsx_child`.
     fn print_jsx_children_compact(&mut self, children: &[JSXChild<'a>]) {
         let refs: Vec<&JSXChild<'a>> = children.iter().collect();
-        self.print_jsx_children_compact_refs(&refs);
+        self.print_jsx_children_compact_refs(&refs, false);
     }
 
-    /// Reference-slice variant of [`Self::print_jsx_children_compact`]: slot
-    /// bodies hold their children as `Vec<&JSXChild>`, so they route here to get
-    /// the same whitespace collapsing as regular element children.
-    fn print_jsx_children_compact_refs(&mut self, children: &[&JSXChild<'a>]) {
+    fn print_jsx_children_compact_refs(&mut self, children: &[&JSXChild<'a>], in_slot_body: bool) {
         let compact = self.options.compact;
 
         // Pre-compute which children will be extracted (produce no output),
@@ -1382,6 +1379,11 @@ impl<'a> AstroCodegen<'a> {
                 if text.value.as_str().chars().all(|c| c.is_ascii_whitespace())
                     && is_edge_whitespace(children, &extracted, i)
                 {
+                    continue;
+                }
+                // A component may render `<slot />` into a whitespace-sensitive context.
+                if in_slot_body && compact == CompactMode::Jsx && !text.value.trim().is_empty() {
+                    self.print_jsx_child(child);
                     continue;
                 }
                 let is_lone = visible_count == 1;

--- a/crates/astro_codegen/src/printer/slots.rs
+++ b/crates/astro_codegen/src/printer/slots.rs
@@ -356,17 +356,13 @@ impl<'a> AstroCodegen<'a> {
         self.print("`");
     }
 
-    /// Emit slot body children. Under compact mode they route through the shared
-    /// whitespace-collapsing path so slotted content is trimmed like regular
-    /// template children; with compact disabled they are emitted verbatim, which
-    /// is what the Go compiler does for slot whitespace.
     fn print_slot_children(&mut self, children: &[&JSXChild<'a>]) {
         if self.options.compact == CompactMode::Disabled {
             for child in children {
                 self.print_jsx_child(child);
             }
         } else {
-            self.print_jsx_children_compact_refs(children);
+            self.print_jsx_children_compact_refs(children, true);
         }
     }
 

--- a/crates/astro_codegen/tests/fixtures/compact__jsx_slot_pre_newlines_128.astro
+++ b/crates/astro_codegen/tests/fixtures/compact__jsx_slot_pre_newlines_128.astro
@@ -1,0 +1,12 @@
+// @config compact=jsx
+---
+import Dropdown from './Dropdown.astro';
+---
+<Dropdown title="Pre in custom component">
+First line
+Second line
+</Dropdown>
+<Dropdown title="Elements">
+  <p>Hello</p>
+  <p>World</p>
+</Dropdown>

--- a/crates/astro_codegen/tests/fixtures/compact__jsx_slot_pre_newlines_128.snap
+++ b/crates/astro_codegen/tests/fixtures/compact__jsx_slot_pre_newlines_128.snap
@@ -1,0 +1,25 @@
+---
+source: crates/astro_codegen/tests/snapshots.rs
+input_file: crates/astro_codegen/tests/fixtures/compact__jsx_slot_pre_newlines_128.astro
+---
+import { render as $$render, createComponent as $$createComponent, renderComponent as $$renderComponent, maybeRenderHead as $$maybeRenderHead, createMetadata as $$createMetadata } from "http://localhost:3000/";
+import Dropdown from "./Dropdown.astro";
+import * as $$module1 from "./Dropdown.astro";
+export const $$metadata = $$createMetadata(import.meta.url, {
+	modules: [{
+		module: $$module1,
+		specifier: "./Dropdown.astro",
+		assert: {}
+	}],
+	hydratedComponents: [],
+	clientOnlyComponents: [],
+	hydrationDirectives: new Set([]),
+	hoisted: []
+});
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+	return $$render`${$$renderComponent($$result, "Dropdown", Dropdown, { "title": "Pre in custom component" }, { "default": () => $$render`
+First line
+Second line
+` })}${$$renderComponent($$result, "Dropdown", Dropdown, { "title": "Elements" }, { "default": () => $$render`${$$maybeRenderHead($$result)}<p>Hello</p><p>World</p>` })}`;
+}, undefined, undefined);
+export default $$Component;


### PR DESCRIPTION
Fixes #128