### PR TITLE
fix(codegen): emit source annotations

### DIFF
--- a/.changeset/annotate-source-file.md
+++ b/.changeset/annotate-source-file.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/compiler-binding": patch
+"@astrojs/compiler-rs": patch
+---
+
+Emits `data-astro-source-file` and `data-astro-source-loc` attributes when source annotation is enabled.

--- a/crates/astro_codegen/src/options.rs
+++ b/crates/astro_codegen/src/options.rs
@@ -112,9 +112,7 @@ pub struct TransformOptions {
     /// `import "transitions.css";` for components that use transition directives.
     pub transitions_animation_url: Option<String>,
 
-    /// Whether to annotate generated code with the source file path.
-    ///
-    /// **Stub**: accepted for API compatibility.
+    /// Whether rendered HTML elements include source file and source location attributes.
     pub annotate_source_file: bool,
 
     /// Whether to strip HTML comments from component slot children.
@@ -279,7 +277,7 @@ impl TransformOptions {
         self
     }
 
-    /// Enable or disable source file annotation (stub).
+    /// Enable or disable source file annotation.
     #[must_use]
     pub fn with_annotate_source_file(mut self, enabled: bool) -> Self {
         self.annotate_source_file = enabled;

--- a/crates/astro_codegen/src/printer/components.rs
+++ b/crates/astro_codegen/src/printer/components.rs
@@ -19,6 +19,35 @@ use crate::scanner::{
 };
 use oxc_ast::ast::*;
 
+fn source_location(source_text: &str, byte_offset: u32) -> (u32, u32) {
+    let offset = (byte_offset as usize).min(source_text.len());
+    let bytes = source_text.as_bytes();
+    let mut line = 1u32;
+    let mut line_start = 0usize;
+    let mut index = 0usize;
+
+    while index < offset {
+        match bytes[index] {
+            b'\r' => {
+                line += 1;
+                if bytes.get(index + 1) == Some(&b'\n') && index + 1 < offset {
+                    index += 1;
+                }
+                line_start = index + 1;
+            }
+            b'\n' => {
+                line += 1;
+                line_start = index + 1;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    let column = source_text[line_start..offset].encode_utf16().count() as u32;
+    (line, column)
+}
+
 /// A client hydration directive parsed from a component's attributes.
 pub(super) enum HydrationDirective {
     /// `client:only="framework"` — component is not rendered server-side.
@@ -206,6 +235,18 @@ impl<'a> AstroCodegen<'a> {
         // attached to them here.
         let inject_define_vars = is_custom && !self.define_vars_values.is_empty();
 
+        let source_annotation = if is_custom && self.options.annotate_source_file {
+            self.options.filename.as_ref().map(|filename| {
+                let (line, column) = source_location(self.source_text, el.opening_element.span.start);
+                (
+                    escape_double_quotes(filename).into_owned(),
+                    format!("{line}:{column}"),
+                )
+            })
+        } else {
+            None
+        };
+
         // Components always receive slot as a prop.
         // Only HTML elements have the slot attribute stripped when inside named slots.
         let prev_skip_slot = self.skip_slot_attribute;
@@ -223,6 +264,9 @@ impl<'a> AstroCodegen<'a> {
             },
             scope_id.as_ref(),
             inject_define_vars,
+            source_annotation
+                .as_ref()
+                .map(|(filename, location)| (filename.as_str(), location.as_str())),
         );
 
         self.skip_slot_attribute = prev_skip_slot;
@@ -338,6 +382,7 @@ impl<'a> AstroCodegen<'a> {
         skip_names: Option<&[&str]>,
         scope_id: Option<&ScopeId>,
         inject_define_vars: bool,
+        source_annotation: Option<(&str, &str)>,
     ) {
         let mut first = true;
 
@@ -584,6 +629,20 @@ impl<'a> AstroCodegen<'a> {
             first = false;
             self.print("\"style\":($$definedVars)");
             self.define_vars_injected = true;
+        }
+
+        if let Some((filename, location)) = source_annotation {
+            if !first {
+                self.print(",");
+            }
+            first = false;
+            self.print_parts([
+                "\"data-astro-source-file\":\"",
+                filename,
+                "\",\"data-astro-source-loc\":\"",
+                location,
+                "\"",
+            ]);
         }
 
         // Add hydration attributes if present

--- a/crates/astro_codegen/src/printer/elements.rs
+++ b/crates/astro_codegen/src/printer/elements.rs
@@ -36,7 +36,7 @@ impl ScopeId {
         }
     }
 
-    /// The attribute name for the `attribute` strategy (e.g. `"data-astro-cid-{hash}"`).
+    /// The attribute name for the `attribute` strategy (e.g. `"data-astro-cid-{hash}`) as a boolean attribute.
     pub(super) fn data_attr_name(&self) -> String {
         match self {
             ScopeId::DataAttribute(v) => format!("data-astro-cid-{v}"),
@@ -90,6 +90,35 @@ pub(super) fn is_head_element(name: &str) -> bool {
     )
 }
 
+fn source_location(source_text: &str, byte_offset: u32) -> (u32, u32) {
+    let offset = (byte_offset as usize).min(source_text.len());
+    let bytes = source_text.as_bytes();
+    let mut line = 1u32;
+    let mut line_start = 0usize;
+    let mut index = 0usize;
+
+    while index < offset {
+        match bytes[index] {
+            b'\r' => {
+                line += 1;
+                if bytes.get(index + 1) == Some(&b'\n') && index + 1 < offset {
+                    index += 1;
+                }
+                line_start = index + 1;
+            }
+            b'\n' => {
+                line += 1;
+                line_start = index + 1;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    let column = source_text[line_start..offset].encode_utf16().count() as u32;
+    (line, column)
+}
+
 impl<'a> AstroCodegen<'a> {
     pub(super) fn add_transition_source_mapping(
         &mut self,
@@ -111,6 +140,29 @@ impl<'a> AstroCodegen<'a> {
         } else {
             None
         }
+    }
+
+    fn print_source_annotation(&mut self, name: &str, span: oxc_span::Span) {
+        if !self.options.annotate_source_file
+            || name == "html"
+            || !css_scoping::should_scope_element(name)
+        {
+            return;
+        }
+
+        let Some(filename) = self.options.filename.clone() else {
+            return;
+        };
+        let filename = escape_html_attribute(&filename).into_owned();
+        let (line, column) = source_location(self.source_text, span.start);
+        let location = format!("{line}:{column}");
+        self.print_parts([
+            " data-astro-source-file=\"",
+            &filename,
+            "\" data-astro-source-loc=\"",
+            &location,
+            "\"",
+        ]);
     }
 
     /// Print an HTML (non-component) element.
@@ -167,6 +219,7 @@ impl<'a> AstroCodegen<'a> {
             scope_id.as_ref(),
             inject_define_vars,
         );
+        self.print_source_annotation(name, el.opening_element.span);
 
         self.print(">");
 

--- a/crates/astro_codegen/tests/annotation.rs
+++ b/crates/astro_codegen/tests/annotation.rs
@@ -1,0 +1,66 @@
+use astro_codegen::{TransformOptions, transform};
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+fn compile(source: &str, annotate: bool) -> String {
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, source, SourceType::astro()).parse_astro();
+    assert!(ret.errors.is_empty(), "Parse errors: {:?}", ret.errors);
+
+    let options = TransformOptions::new()
+        .with_internal_url("http://localhost:3000/")
+        .with_filename("/src/pages/index.astro")
+        .with_annotate_source_file(annotate);
+
+    transform(&allocator, source, options, &ret.root).code
+}
+
+#[test]
+fn annotates_html_elements_when_enabled() {
+    let output = compile("<h1>Hello</h1>", true);
+
+    assert!(output.contains(
+        "<h1 data-astro-source-file=\"/src/pages/index.astro\" data-astro-source-loc=\"1:0\">Hello</h1>"
+    ));
+}
+
+#[test]
+fn leaves_html_elements_unannotated_when_disabled() {
+    let output = compile("<h1>Hello</h1>", false);
+
+    assert!(!output.contains("data-astro-source-file"));
+    assert!(!output.contains("data-astro-source-loc"));
+}
+
+#[test]
+fn reports_multiline_and_utf16_source_locations() {
+    let output = compile("😀<span>first</span>\n  <div>second</div>", true);
+
+    assert!(output.contains(
+        "<span data-astro-source-file=\"/src/pages/index.astro\" data-astro-source-loc=\"1:2\">first</span>"
+    ));
+    assert!(output.contains(
+        "<div data-astro-source-file=\"/src/pages/index.astro\" data-astro-source-loc=\"2:2\">second</div>"
+    ));
+}
+
+#[test]
+fn skips_components_and_never_scoped_elements() {
+    let source = r#"---
+import Component from "./Component.astro";
+---
+<html><head><title>Title</title></head><Component /><div>Body</div></html>"#;
+    let output = compile(source, true);
+
+    assert_eq!(output.matches("data-astro-source-file").count(), 1);
+    assert!(output.contains("<div data-astro-source-file=\"/src/pages/index.astro\""));
+}
+
+#[test]
+fn annotates_custom_elements() {
+    let output = compile("<my-element>Hi</my-element>", true);
+
+    assert!(output.contains("\"data-astro-source-file\":\"/src/pages/index.astro\""));
+    assert!(output.contains("\"data-astro-source-loc\":\"1:0\""));
+}


### PR DESCRIPTION
## Changes

- emit `data-astro-source-file` and `data-astro-source-loc` when `annotateSourceFile` is enabled
- match the legacy compiler by skipping Astro/framework components and never-scoped elements while annotating custom elements
- add regression coverage for disabled behavior, UTF-16 source locations, exclusions, and custom elements

Fixes #96

## Testing

Added focused `astro_codegen` regression tests for the annotation behavior. Local Rust execution is unavailable in this environment, so this draft uses the repository CI as the build, formatting, Clippy, and test verification gate.

## Docs

Updated the `TransformOptions::annotate_source_file` documentation to reflect that the option is implemented. No public documentation changes are needed.

Prepared with ChatGPT’s assistance.