### PR TITLE
fix(napi): skip mimalloc allocator on Android targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,15 +151,15 @@ jobs:
             target: aarch64-unknown-linux-musl
             build: pnpm run build --target aarch64-unknown-linux-musl -x
 
+          # -- Android --
+          - host: ubuntu-latest
+            target: aarch64-linux-android
+            build: pnpm run build --target aarch64-linux-android
+
           # -- WASM (fallback for all other platforms) --
           - host: ubuntu-latest
             target: wasm32-wasip1-threads
             build: pnpm run build --target wasm32-wasip1-threads
-            
-          # -- Linux ARM64 -- 
-          - host: ubuntu-latest
-            target: aarch64-linux-android
-            build: pnpm run build --target aarch64-linux-android --use-napi-cross
 
     name: Build - ${{ matrix.settings.target }}
     runs-on: ${{ matrix.settings.host }}

--- a/crates/astro_napi/package.json
+++ b/crates/astro_napi/package.json
@@ -55,6 +55,7 @@
     "packageName": "@astrojs/compiler-binding",
     "targets": [
       "aarch64-apple-darwin",
+      "aarch64-linux-android",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
       "aarch64-unknown-linux-musl",
@@ -62,8 +63,7 @@
       "x86_64-apple-darwin",
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-linux-musl",
-      "aarch64-linux-android"
+      "x86_64-unknown-linux-musl"
     ],
     "wasm": {
       "browser": {

--- a/crates/astro_napi/src/lib.rs
+++ b/crates/astro_napi/src/lib.rs
@@ -7,6 +7,7 @@ mod error;
     feature = "allocator",
     not(any(
         target_arch = "arm",
+        target_os = "android",
         target_os = "freebsd",
         target_os = "windows",
         target_family = "wasm"


### PR DESCRIPTION
## Changes

mimalloc isn't available on Android, so we need to skip like we do on many platforms. Additionally, NAPI's cross compilation don't support Android, we shouldn't use it to build

## Testing

We'll see if it builds!

## Docs

N/A